### PR TITLE
Tags: `if_exists` flag for include tag

### DIFF
--- a/pongo2_template_test.go
+++ b/pongo2_template_test.go
@@ -124,6 +124,7 @@ var tplContext = Context{
 		"number":        42,
 		"name":          "john doe",
 		"included_file": "INCLUDES.helper",
+		"included_file_not_exists": "INCLUDES.helper.not_exists",
 		"nil":           nil,
 		"uint":          uint(8),
 		"float":         float64(3.1415),

--- a/template_tests/includes.tpl
+++ b/template_tests/includes.tpl
@@ -1,4 +1,7 @@
 Start '{% include "includes.helper" %}' End
+Start '{% include "includes.helper" if_exists %}' End
 Start '{% include "includes.helper" with what_am_i=simple.name only %}' End
 Start '{% include "includes.helper" with what_am_i=simple.name %}' End
 Start '{% include simple.included_file|lower with number=7 what_am_i="guest" %}' End
+Start '{% include "includes.helper.not_exists" if_exists %}' End
+Start '{% include simple.included_file_not_exists if_exists with number=7 what_am_i="guest" %}' End

--- a/template_tests/includes.tpl.out
+++ b/template_tests/includes.tpl.out
@@ -1,4 +1,7 @@
 Start 'I'm 11' End
+Start 'I'm 11' End
 Start 'I'm john doe' End
 Start 'I'm john doe11' End
 Start 'I'm guest7' End
+Start '' End
+Start '' End


### PR DESCRIPTION
Hello

Let me introduce the `if_exists` flag for `include` tag. 
The main idea of this flag was the need to include files that can not exist with out error (like normal behaviour).

For example your application is running on a huge website and your website has different layouts or part of layouts for each venture. 

For example you have VN, SG, MY ventures. And each venture has its own folder with templates `templates/VENTURE_CODE/` but all file names are the same. And you need to include to the meta tag Alexa code for VN venture. 

Ok, the best way to create new file `templates/VN/partial/alexa_code.html` and then just include it to the main layout file like this `{% include "partial/alexa_code.html" %}`. Everything is fine except for one: somebody forgot to create `alexa_code.html` for and MY and SG ventures. And everything is broken ;)

Now you will have a solution! ;)
Just put `{% include "partial/alexa_code.html" if_exists %}` and you save your ass out of troubles!

Regards
Maksim
