### PR TITLE
Add implicit *ExecutionContext arg for function calls

### DIFF
--- a/pongo2_test.go
+++ b/pongo2_test.go
@@ -64,3 +64,38 @@ func (s *TestSuite) TestMisc(c *C) {
 		}
 	}, PanicMatches, `\[Error \(where: applyfilter\)\] Filter with name 'doesnotexist' not found.`)
 }
+
+func (s *TestSuite) TestImplicitExecCtx(c *C) {
+	tpl, err := FromString("{{ ImplicitExec }}")
+	if err != nil {
+		c.Fatalf("Error in FromString: %v", err)
+	}
+
+	val := "a stringy thing"
+
+	res, err := tpl.Execute(Context{
+		"Value": val,
+		"ImplicitExec": func(ctx *ExecutionContext) string {
+			return ctx.Public["Value"].(string)
+		},
+	})
+
+	if err != nil {
+		c.Fatalf("Error executing template: %v", err)
+	}
+
+	c.Check(res, Equals, val)
+
+	// The implicit ctx should not be persisted from call-to-call
+	res, err = tpl.Execute(Context{
+		"ImplicitExec": func() string {
+			return val
+		},
+	})
+
+	if err != nil {
+		c.Fatalf("Error executing template: %v", err)
+	}
+
+	c.Check(res, Equals, val)
+}

--- a/variable.go
+++ b/variable.go
@@ -12,6 +12,11 @@ const (
 	varTypeIdent
 )
 
+var (
+	typeOfValuePtr   = reflect.TypeOf(new(Value))
+	typeOfExecCtxPtr = reflect.TypeOf(new(ExecutionContext))
+)
+
 type variablePart struct {
 	typ int
 	s   string
@@ -63,6 +68,8 @@ type nodeVariable struct {
 	locationToken *Token
 	expr          IEvaluator
 }
+
+type executionCtxEval struct{}
 
 func (v *nodeFilteredVariable) Execute(ctx *ExecutionContext, writer TemplateWriter) *Error {
 	value, err := v.Evaluate(ctx)
@@ -196,6 +203,10 @@ func (nv *nodeVariable) Execute(ctx *ExecutionContext, writer TemplateWriter) *E
 	return nil
 }
 
+func (executionCtxEval) Evaluate(ctx *ExecutionContext) (*Value, *Error) {
+	return AsValue(ctx), nil
+}
+
 func (vr *variableResolver) FilterApplied(name string) bool {
 	return false
 }
@@ -294,7 +305,7 @@ func (vr *variableResolver) resolve(ctx *ExecutionContext) (*Value, error) {
 		// If current is a reflect.ValueOf(pongo2.Value), then unpack it
 		// Happens in function calls (as a return value) or by injecting
 		// into the execution context (e.g. in a for-loop)
-		if current.Type() == reflect.TypeOf(&Value{}) {
+		if current.Type() == typeOfValuePtr {
 			tmpValue := current.Interface().(*Value)
 			current = tmpValue.val
 			isSafe = tmpValue.safe
@@ -315,12 +326,18 @@ func (vr *variableResolver) resolve(ctx *ExecutionContext) (*Value, error) {
 			// Check for correct function syntax and types
 			// func(*Value, ...) *Value
 			t := current.Type()
+			currArgs := part.callingArgs
+
+			// If an implicit ExecCtx is needed
+			if t.NumIn() > 0 && t.In(0) == typeOfExecCtxPtr {
+				 currArgs = append([]functionCallArgument{executionCtxEval{}}, currArgs...)
+			}
 
 			// Input arguments
-			if len(part.callingArgs) != t.NumIn() && !(len(part.callingArgs) >= t.NumIn()-1 && t.IsVariadic()) {
+			if len(currArgs) != t.NumIn() && !(len(currArgs) >= t.NumIn()-1 && t.IsVariadic()) {
 				return nil,
 					fmt.Errorf("Function input argument count (%d) of '%s' must be equal to the calling argument count (%d).",
-						t.NumIn(), vr.String(), len(part.callingArgs))
+						t.NumIn(), vr.String(), len(currArgs))
 			}
 
 			// Output arguments
@@ -335,7 +352,7 @@ func (vr *variableResolver) resolve(ctx *ExecutionContext) (*Value, error) {
 			isVariadic := t.IsVariadic()
 			var fnArg reflect.Type
 
-			for idx, arg := range part.callingArgs {
+			for idx, arg := range currArgs {
 				pv, err := arg.Evaluate(ctx)
 				if err != nil {
 					return nil, err
@@ -351,7 +368,7 @@ func (vr *variableResolver) resolve(ctx *ExecutionContext) (*Value, error) {
 					fnArg = t.In(idx)
 				}
 
-				if fnArg != reflect.TypeOf(new(Value)) {
+				if fnArg != typeOfValuePtr {
 					// Function's argument is not a *pongo2.Value, then we have to check whether input argument is of the same type as the function's argument
 					if !isVariadic {
 						if fnArg != reflect.TypeOf(pv.Interface()) && fnArg.Kind() != reflect.Interface {
@@ -377,7 +394,7 @@ func (vr *variableResolver) resolve(ctx *ExecutionContext) (*Value, error) {
 			// Call it and get first return parameter back
 			rv := current.Call(parameters)[0]
 
-			if rv.Type() != reflect.TypeOf(new(Value)) {
+			if rv.Type() != typeOfValuePtr {
 				current = reflect.ValueOf(rv.Interface())
 			} else {
 				// Return the function call value


### PR DESCRIPTION
When calling out of templates to functions in go, it's often times useful to be able to access the *ExecutionContext of the template. Rather than forcing all functions to take this argument, it's best just to perform a quick check to see if the function wants the context, and add if it does.