### PR TITLE
Proper tagging for ifnotequal

### DIFF
--- a/tags_ifnotequal.go
+++ b/tags_ifnotequal.go
@@ -47,7 +47,7 @@ func tagIfNotEqualParser(doc *Parser, start *Token, arguments *Parser) (INodeTag
 	}
 
 	// Wrap then/else-blocks
-	wrapper, endargs, err := doc.WrapUntilTag("else", "endifequal")
+	wrapper, endargs, err := doc.WrapUntilTag("else", "endifnotequal")
 	if err != nil {
 		return nil, err
 	}
@@ -59,7 +59,7 @@ func tagIfNotEqualParser(doc *Parser, start *Token, arguments *Parser) (INodeTag
 
 	if wrapper.Endtag == "else" {
 		// if there's an else in the if-statement, we need the else-Block as well
-		wrapper, endargs, err = doc.WrapUntilTag("endifequal")
+		wrapper, endargs, err = doc.WrapUntilTag("endifnotequal")
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
The proper end tag in Django for {%ifnotequal%} should be {%endifnotequal%}. We can see this reflected in the official [Django repo](https://github.com/django/django/blob/8047e3666b0b50bb04e6f16c2a4fb21ddfd5713f/tests/template_tests/syntax_tests/test_if_equal.py#L199). This pull request changes the tag to reflect this. 