### PR TITLE
TemplateSet converted to an interface

### DIFF
--- a/debugger.go
+++ b/debugger.go
@@ -1,0 +1,6 @@
+package pongo2
+
+type Debugger interface {
+	Debug() bool
+	SetDebug(bool)
+}

--- a/error.go
+++ b/error.go
@@ -66,7 +66,7 @@ func (e *Error) RawLine() (line string, available bool) {
 
 	filename := e.Filename
 	if e.Template != nil {
-		filename = e.Template.set.resolveFilename(e.Template, e.Filename)
+		filename = e.Template.set.ResolvePath(e.Template, e.Filename)
 	}
 	file, err := os.Open(filename)
 	if err != nil {

--- a/pongo2_template_test.go
+++ b/pongo2_template_test.go
@@ -89,22 +89,22 @@ func init() {
 	if err != nil {
 		panic(err)
 	}
-	DefaultSet.SandboxDirectories = append(DefaultSet.SandboxDirectories, absPath)
+	DefaultSet.AddSandboxDirectory(absPath)
 
 	absPath, err = filepath.Abs("./template_tests/*/*")
 	if err != nil {
 		panic(err)
 	}
-	DefaultSet.SandboxDirectories = append(DefaultSet.SandboxDirectories, absPath)
+	DefaultSet.AddSandboxDirectory(absPath)
 
 	absPath, err = filepath.Abs("./template_tests/*/*/*")
 	if err != nil {
 		panic(err)
 	}
-	DefaultSet.SandboxDirectories = append(DefaultSet.SandboxDirectories, absPath)
+	DefaultSet.AddSandboxDirectory(absPath)
 
 	// Allow pongo2 temp files
-	DefaultSet.SandboxDirectories = append(DefaultSet.SandboxDirectories, "/tmp/pongo2_*")
+	DefaultSet.AddSandboxDirectory(absPath)
 
 	f, err := ioutil.TempFile("/tmp/", "pongo2_")
 	if err != nil {

--- a/pongo2_template_test.go
+++ b/pongo2_template_test.go
@@ -107,14 +107,15 @@ func init() {
 
 		// Allow pongo2 temp files
 		sandboxed.AddSandboxDirectory(absPath)
-	}
 
-	f, err := ioutil.TempFile("/tmp/", "pongo2_")
-	if err != nil {
-		panic("cannot write to /tmp/")
+		f, err := ioutil.TempFile("/tmp/", "pongo2_")
+		if err != nil {
+			panic("cannot write to /tmp/")
+		}
+		f.Write([]byte("Hello from pongo2"))
+		DefaultSet.Globals()["temp_file"] = f.Name()
+		sandboxed.AddSandboxDirectory("/tmp/pongo2_*")
 	}
-	f.Write([]byte("Hello from pongo2"))
-	DefaultSet.Globals()["temp_file"] = f.Name()
 
 	// Alternate TemplateImplementation
 }

--- a/pongo2_template_test.go
+++ b/pongo2_template_test.go
@@ -74,44 +74,49 @@ func BannedFilterFn(in *Value, params *Value) (*Value, *Error) {
 }
 
 func init() {
-	DefaultSet.Debug = true
+	//TODO add Debug support back in via interface
+	//DefaultSet.Debug = true
 
 	RegisterFilter("banned_filter", BannedFilterFn)
 	RegisterFilter("unbanned_filter", BannedFilterFn)
 	RegisterTag("banned_tag", tagSandboxDemoTagParser)
 	RegisterTag("unbanned_tag", tagSandboxDemoTagParser)
 
-	DefaultSet.BanFilter("banned_filter")
-	DefaultSet.BanTag("banned_tag")
+	if sandboxed, ok := DefaultSet.(TemplateSandboxer); ok == true {
+		sandboxed.BanFilter("banned_filter")
+		sandboxed.BanTag("banned_tag")
 
-	// Allow different kind of levels inside template_tests/
-	absPath, err := filepath.Abs("./template_tests/*")
-	if err != nil {
-		panic(err)
+		// Allow different kind of levels inside template_tests/
+		absPath, err := filepath.Abs("./template_tests/*")
+		if err != nil {
+			panic(err)
+		}
+		sandboxed.AddSandboxDirectory(absPath)
+
+		absPath, err = filepath.Abs("./template_tests/*/*")
+		if err != nil {
+			panic(err)
+		}
+		sandboxed.AddSandboxDirectory(absPath)
+
+		absPath, err = filepath.Abs("./template_tests/*/*/*")
+		if err != nil {
+			panic(err)
+		}
+		sandboxed.AddSandboxDirectory(absPath)
+
+		// Allow pongo2 temp files
+		sandboxed.AddSandboxDirectory(absPath)
 	}
-	DefaultSet.AddSandboxDirectory(absPath)
-
-	absPath, err = filepath.Abs("./template_tests/*/*")
-	if err != nil {
-		panic(err)
-	}
-	DefaultSet.AddSandboxDirectory(absPath)
-
-	absPath, err = filepath.Abs("./template_tests/*/*/*")
-	if err != nil {
-		panic(err)
-	}
-	DefaultSet.AddSandboxDirectory(absPath)
-
-	// Allow pongo2 temp files
-	DefaultSet.AddSandboxDirectory(absPath)
 
 	f, err := ioutil.TempFile("/tmp/", "pongo2_")
 	if err != nil {
 		panic("cannot write to /tmp/")
 	}
 	f.Write([]byte("Hello from pongo2"))
-	DefaultSet.Globals["temp_file"] = f.Name()
+	DefaultSet.Globals()["temp_file"] = f.Name()
+
+	// Alternate TemplateImplementation
 }
 
 /*
@@ -251,7 +256,7 @@ func TestTemplates(t *testing.T) {
 	debug = true
 
 	// Add a global to the default set
-	Globals["this_is_a_global_variable"] = "this is a global text"
+	DefaultSet.Globals()["this_is_a_global_variable"] = "this is a global text"
 
 	matches, err := filepath.Glob("./template_tests/*.tpl")
 	if err != nil {
@@ -259,7 +264,7 @@ func TestTemplates(t *testing.T) {
 	}
 	for idx, match := range matches {
 		t.Logf("[Template %3d] Testing '%s'", idx+1, match)
-		tpl, err := FromFile(match)
+		tpl, err := DefaultSet.FromPath(match)
 		if err != nil {
 			t.Fatalf("Error on FromFile('%s'): %s", match, err.Error())
 		}
@@ -318,7 +323,7 @@ func TestExecutionErrors(t *testing.T) {
 					match, idx+1)
 			}
 
-			tpl, err := FromString(test)
+			tpl, err := DefaultSet.FromString(test)
 			if err != nil {
 				t.Fatalf("Error on FromString('%s'): %s", test, err.Error())
 			}
@@ -371,7 +376,7 @@ func TestCompilationErrors(t *testing.T) {
 					match, idx+1)
 			}
 
-			_, err = FromString(test)
+			_, err = DefaultSet.FromString(test)
 			if err == nil {
 				t.Fatalf("[%s | Line %d] Expected error for (got none): %s", match, idx+1, tests[idx])
 			}
@@ -387,9 +392,9 @@ func TestCompilationErrors(t *testing.T) {
 func TestBaseDirectory(t *testing.T) {
 	mustStr := "Hello from template_tests/base_dir_test/"
 
-	s := NewSet("test set with base directory")
-	s.Globals["base_directory"] = "template_tests/base_dir_test/"
-	if err := s.SetBaseDirectory(s.Globals["base_directory"].(string)); err != nil {
+	s := NewFileSet("test set with base directory")
+	s.Globals()["base_directory"] = "template_tests/base_dir_test/"
+	if err := s.SetBasePath(s.Globals()["base_directory"].(string)); err != nil {
 		t.Fatal(err)
 	}
 
@@ -400,7 +405,7 @@ func TestBaseDirectory(t *testing.T) {
 	for _, match := range matches {
 		match = strings.Replace(match, "template_tests/base_dir_test/", "", -1)
 
-		tpl, err := s.FromFile(match)
+		tpl, err := s.FromPath(match)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -415,9 +420,10 @@ func TestBaseDirectory(t *testing.T) {
 }
 
 func BenchmarkCache(b *testing.B) {
-	cache_set := NewSet("cache set")
+	cache_set := NewFileSet("cache set")
+	template_set_cache := cache_set.(TemplateSetCacher)
 	for i := 0; i < b.N; i++ {
-		tpl, err := cache_set.FromCache("template_tests/complex.tpl")
+		tpl, err := template_set_cache.FromCache("template_tests/complex.tpl")
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -429,10 +435,10 @@ func BenchmarkCache(b *testing.B) {
 }
 
 func BenchmarkCacheDebugOn(b *testing.B) {
-	cache_debug_set := NewSet("cache set")
-	cache_debug_set.Debug = true
+	cache_debug_set := NewFileSet("cache set")
+	cache_debug_set.SetDebug(true)
 	for i := 0; i < b.N; i++ {
-		tpl, err := cache_debug_set.FromFile("template_tests/complex.tpl")
+		tpl, err := cache_debug_set.FromPath("template_tests/complex.tpl")
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -444,7 +450,7 @@ func BenchmarkCacheDebugOn(b *testing.B) {
 }
 
 func BenchmarkExecuteComplexWithSandboxActive(b *testing.B) {
-	tpl, err := FromFile("template_tests/complex.tpl")
+	tpl, err := DefaultSet.FromPath("template_tests/complex.tpl")
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -465,7 +471,7 @@ func BenchmarkCompileAndExecuteComplexWithSandboxActive(b *testing.B) {
 	preloadedTpl := string(buf)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		tpl, err := FromString(preloadedTpl)
+		tpl, err := DefaultSet.FromString(preloadedTpl)
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -478,7 +484,7 @@ func BenchmarkCompileAndExecuteComplexWithSandboxActive(b *testing.B) {
 }
 
 func BenchmarkParallelExecuteComplexWithSandboxActive(b *testing.B) {
-	tpl, err := FromFile("template_tests/complex.tpl")
+	tpl, err := DefaultSet.FromPath("template_tests/complex.tpl")
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -494,8 +500,8 @@ func BenchmarkParallelExecuteComplexWithSandboxActive(b *testing.B) {
 }
 
 func BenchmarkExecuteComplexWithoutSandbox(b *testing.B) {
-	s := NewSet("set without sandbox")
-	tpl, err := s.FromFile("template_tests/complex.tpl")
+	s := NewFileSet("set without sandbox")
+	tpl, err := s.FromPath("template_tests/complex.tpl")
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -515,7 +521,7 @@ func BenchmarkCompileAndExecuteComplexWithoutSandbox(b *testing.B) {
 	}
 	preloadedTpl := string(buf)
 
-	s := NewSet("set without sandbox")
+	s := NewFileSet("set without sandbox")
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -532,8 +538,8 @@ func BenchmarkCompileAndExecuteComplexWithoutSandbox(b *testing.B) {
 }
 
 func BenchmarkParallelExecuteComplexWithoutSandbox(b *testing.B) {
-	s := NewSet("set without sandbox")
-	tpl, err := s.FromFile("template_tests/complex.tpl")
+	s := NewFileSet("set without sandbox")
+	tpl, err := s.FromPath("template_tests/complex.tpl")
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/pongo2_test.go
+++ b/pongo2_test.go
@@ -16,7 +16,7 @@ type TestSuite struct {
 
 var (
 	_          = Suite(&TestSuite{})
-	testSuite2 = NewSet("test suite 2")
+	testSuite2 = NewFileSet("test suite 2")
 )
 
 func parseTemplate(s string, c Context) string {
@@ -40,7 +40,7 @@ func parseTemplateFn(s string, c Context) func() {
 func (s *TestSuite) TestMisc(c *C) {
 	// Must
 	// TODO: Add better error message (see issue #18)
-	c.Check(func() { Must(testSuite2.FromFile("template_tests/inheritance/base2.tpl")) },
+	c.Check(func() { Must(testSuite2.FromPath("template_tests/inheritance/base2.tpl")) },
 		PanicMatches,
 		`\[Error \(where: fromfile\) in template_tests/inheritance/doesnotexist.tpl | Line 1 Col 12 near 'doesnotexist.tpl'\] open template_tests/inheritance/doesnotexist.tpl: no such file or directory`)
 

--- a/tags.go
+++ b/tags.go
@@ -102,8 +102,11 @@ func (p *Parser) parseTagElement() (INodeTag, *Error) {
 	}
 
 	// Check sandbox tag restriction
-	if _, isBanned := p.template.set.bannedTags[tokenName.Val]; isBanned {
-		return nil, p.Error(fmt.Sprintf("Usage of tag '%s' is not allowed (sandbox restriction active).", tokenName.Val), tokenName)
+	if sandbox, ok := p.template.set.(TemplateSandboxer); ok {
+		bannedTags := sandbox.BannedTags()
+		if _, isBanned := bannedTags[tokenName.Val]; isBanned {
+			return nil, p.Error(fmt.Sprintf("Usage of tag '%s' is not allowed (sandbox restriction active).", tokenName.Val), tokenName)
+		}
 	}
 
 	var argsToken []*Token

--- a/tags_extends.go
+++ b/tags_extends.go
@@ -24,10 +24,10 @@ func tagExtendsParser(doc *Parser, start *Token, arguments *Parser) (INodeTag, *
 		// prepared, static template
 
 		// Get parent's filename
-		parentFilename := doc.template.set.resolveFilename(doc.template, filenameToken.Val)
+		parentFilename := doc.template.set.ResolvePath(doc.template, filenameToken.Val)
 
 		// Parse the parent
-		parentTemplate, err := doc.template.set.FromFile(parentFilename)
+		parentTemplate, err := doc.template.set.FromPath(parentFilename)
 		if err != nil {
 			return nil, err.(*Error)
 		}

--- a/tags_import.go
+++ b/tags_import.go
@@ -32,14 +32,14 @@ func tagImportParser(doc *Parser, start *Token, arguments *Parser) (INodeTag, *E
 		return nil, arguments.Error("Import-tag needs a filename as string.", nil)
 	}
 
-	importNode.filename = doc.template.set.resolveFilename(doc.template, filenameToken.Val)
+	importNode.filename = doc.template.set.ResolvePath(doc.template, filenameToken.Val)
 
 	if arguments.Remaining() == 0 {
 		return nil, arguments.Error("You must at least specify one macro to import.", nil)
 	}
 
 	// Compile the given template
-	tpl, err := doc.template.set.FromFile(importNode.filename)
+	tpl, err := doc.template.set.FromPath(importNode.filename)
 	if err != nil {
 		return nil, err.(*Error).updateFromTokenIfNeeded(doc.template, start)
 	}

--- a/tags_include.go
+++ b/tags_include.go
@@ -42,9 +42,9 @@ func (node *tagIncludeNode) Execute(ctx *ExecutionContext, writer TemplateWriter
 		}
 
 		// Get include-filename
-		includedFilename := ctx.template.set.resolveFilename(ctx.template, filename.String())
+		includedFilename := ctx.template.set.ResolvePath(ctx.template, filename.String())
 
-		includedTpl, err2 := ctx.template.set.FromFile(includedFilename)
+		includedTpl, err2 := ctx.template.set.FromPath(includedFilename)
 		if err2 != nil {
 			// if this is ReadFile error, and "if_exists" flag is enabled
 			if node.ifExists && err2.(*Error).Sender == "fromfile" {
@@ -84,11 +84,11 @@ func tagIncludeParser(doc *Parser, start *Token, arguments *Parser) (INodeTag, *
 		ifExists := arguments.Match(TokenIdentifier, "if_exists") != nil
 
 		// Get include-filename
-		includedFilename := doc.template.set.resolveFilename(doc.template, filenameToken.Val)
+		includedFilename := doc.template.set.ResolvePath(doc.template, filenameToken.Val)
 
 		// Parse the parent
 		includeNode.filename = includedFilename
-		includedTpl, err := doc.template.set.FromFile(includedFilename)
+		includedTpl, err := doc.template.set.FromPath(includedFilename)
 		if err != nil {
 			// if this is ReadFile error, and "if_exists" token presents we should create and empty node
 			if err.(*Error).Sender == "fromfile" && ifExists {

--- a/tags_ssi.go
+++ b/tags_ssi.go
@@ -36,14 +36,14 @@ func tagSSIParser(doc *Parser, start *Token, arguments *Parser) (INodeTag, *Erro
 
 		if arguments.Match(TokenIdentifier, "parsed") != nil {
 			// parsed
-			temporaryTpl, err := doc.template.set.FromFile(doc.template.set.resolveFilename(doc.template, fileToken.Val))
+			temporaryTpl, err := doc.template.set.FromPath(doc.template.set.ResolvePath(doc.template, fileToken.Val))
 			if err != nil {
 				return nil, err.(*Error).updateFromTokenIfNeeded(doc.template, fileToken)
 			}
 			SSINode.template = temporaryTpl
 		} else {
 			// plaintext
-			buf, err := ioutil.ReadFile(doc.template.set.resolveFilename(doc.template, fileToken.Val))
+			buf, err := ioutil.ReadFile(doc.template.set.ResolvePath(doc.template, fileToken.Val))
 			if err != nil {
 				return nil, (&Error{
 					Sender:   "tag:ssi",

--- a/template.go
+++ b/template.go
@@ -24,7 +24,7 @@ func (tw *templateWriter) Write(b []byte) (int, error) {
 }
 
 type Template struct {
-	set *TemplateSet
+	set TemplateSet
 
 	// Input
 	isTplString bool
@@ -47,11 +47,11 @@ type Template struct {
 	root *nodeDocument
 }
 
-func newTemplateString(set *TemplateSet, tpl string) (*Template, error) {
+func newTemplateString(set TemplateSet, tpl string) (*Template, error) {
 	return newTemplate(set, "<string>", true, tpl)
 }
 
-func newTemplate(set *TemplateSet, name string, isTplString bool, tpl string) (*Template, error) {
+func newTemplate(set TemplateSet, name string, isTplString bool, tpl string) (*Template, error) {
 	// Create the template
 	t := &Template{
 		set:            set,
@@ -93,7 +93,7 @@ func (tpl *Template) execute(context Context, writer TemplateWriter) error {
 
 	// Create context if none is given
 	newContext := make(Context)
-	newContext.Update(tpl.set.Globals)
+	newContext.Update(tpl.set.Globals())
 
 	if context != nil {
 		newContext.Update(context)

--- a/template_sets.go
+++ b/template_sets.go
@@ -42,7 +42,7 @@ type TemplateSandboxer interface {
 	AddSandboxDirectory(directory string)
 
 	// List directories in sandbox
-	SandboxedDirectories() []string
+	SandboxDirectories() []string
 }
 
 // Cache for templates

--- a/variable.go
+++ b/variable.go
@@ -618,8 +618,10 @@ filterLoop:
 		}
 
 		// Check sandbox filter restriction
-		if _, isBanned := p.template.set.bannedFilters[filter.name]; isBanned {
-			return nil, p.Error(fmt.Sprintf("Usage of filter '%s' is not allowed (sandbox restriction active).", filter.name), nil)
+		if sandboxed, ok := p.template.set.(TemplateSandboxer); ok == true {
+			if _, isBanned := sandboxed.BannedFilters()[filter.name]; isBanned {
+				return nil, p.Error(fmt.Sprintf("Usage of filter '%s' is not allowed (sandbox restriction active).", filter.name), nil)
+			}
 		}
 
 		v.filterChain = append(v.filterChain, filter)


### PR DESCRIPTION
First draft PR, not ready for merge but looking for comments/feedback.

This is related to issue #68, where users want to provide an alternate implementation of TemplateSet that can query DB, ObjectStores, etc.

We broke the core of TemplateSet into three interfaces:
- TemplateSet: Generic Accessors, Renderers, etc
- TemplateSetCacher: Cache interface
- TemplateSandboxer: Sandbox interface

_P.S. I dislike naming go interfaces, welcome to suggestions on those. Adding 'er' sometimes sucks..._

All a basic implementation needs to do TemplateSet, but if you want caching or sandboxing also implement those.

We removed all but the `DefaultSet` package global defined `template_set` since globals are "bad" and by design you can use any number of TemplateSet's, which could cause some amusing bugs for those of us with more complicated use cases for TemplateSet. All but Global was used only in the testing, so no great loss IMHO.

Many of these changes to get TemplateSet into an interface do break your current implementations. My understanding is master is going to v4.0 and this may be a good time to break things for people. In nearly all cases, you just need to convert accessing struct members to a method call.

Shoot any questions my way.

Looking to also address issue #87 (TemplateSet panics instead of passing error) in this PR.

Looking for a CR from @kevpie or anyone else willing :smile: 