### PR TITLE
Fix hiding error on processing for tag body

### DIFF
--- a/tags_for.go
+++ b/tags_for.go
@@ -80,7 +80,7 @@ func (node *tagForNode) Execute(ctx *ExecutionContext, writer TemplateWriter) (f
 		}
 	}, node.reversed, node.sorted)
 
-	return nil
+	return forError
 }
 
 func tagForParser(doc *Parser, start *Token, arguments *Parser) (INodeTag, *Error) {

--- a/template_tests/filters-execution.err
+++ b/template_tests/filters-execution.err
@@ -1,3 +1,4 @@
 {{ -(true || false) }}
 {{ simple.func_add("test", 5) }}
+{% for item in simple.multiple_item_list %} {{ simple.func_add("test", 5) }} {% endfor %}
 {{ simple.func_variadic_sum_int("foo") }}

--- a/template_tests/filters-execution.err.out
+++ b/template_tests/filters-execution.err.out
@@ -1,3 +1,4 @@
 .*where: execution.*Negative sign on a non\-number expression
 .*Function input argument 0 of 'simple.func_add' must be of type int or \*pongo2.Value \(not string\).
+.*Function input argument 0 of 'simple.func_add' must be of type int or \*pongo2.Value \(not string\).
 .*Function variadic input argument of 'simple.func_variadic_sum_int' must be of type int or \*pongo2.Value \(not string\).


### PR DESCRIPTION
When we return nil, we override non-nil value set to `forError` while processing for loop body. Here is the fix and a test