### PR TITLE
Add FromBytes

### DIFF
--- a/pongo2_template_test.go
+++ b/pongo2_template_test.go
@@ -302,6 +302,11 @@ func TestExecutionErrors(t *testing.T) {
 				t.Fatalf("Error on FromString('%s'): %s", test, err.Error())
 			}
 
+			tpl, err = pongo2.FromBytes([]byte(test))
+			if err != nil {
+				t.Fatalf("Error on FromBytes('%s'): %s", test, err.Error())
+			}
+
 			_, err = tpl.ExecuteBytes(tplContext)
 			if err == nil {
 				t.Fatalf("[%s Line %d] Expected error for (got none): %s",

--- a/template_sets.go
+++ b/template_sets.go
@@ -153,6 +153,13 @@ func (set *TemplateSet) FromString(tpl string) (*Template, error) {
 	return newTemplateString(set, []byte(tpl))
 }
 
+// FromBytes loads a template from bytes and returns a Template instance.
+func (set *TemplateSet) FromBytes(tpl []byte) (*Template, error) {
+	set.firstTemplateCreated = true
+
+	return newTemplateString(set, tpl)
+}
+
 // FromFile loads a template from a filename and returns a Template instance.
 func (set *TemplateSet) FromFile(filename string) (*Template, error) {
 	set.firstTemplateCreated = true
@@ -183,6 +190,19 @@ func (set *TemplateSet) RenderTemplateString(s string, ctx Context) string {
 	set.firstTemplateCreated = true
 
 	tpl := Must(set.FromString(s))
+	result, err := tpl.Execute(ctx)
+	if err != nil {
+		panic(err)
+	}
+	return result
+}
+
+// RenderTemplateBytes is a shortcut and renders template bytes directly.
+// Panics when providing a malformed template or an error occurs during execution.
+func (set *TemplateSet) RenderTemplateBytes(b []byte, ctx Context) string {
+	set.firstTemplateCreated = true
+
+	tpl := Must(set.FromBytes(b))
 	result, err := tpl.Execute(ctx)
 	if err != nil {
 		panic(err)
@@ -229,6 +249,7 @@ var (
 
 	// Methods on the default set
 	FromString           = DefaultSet.FromString
+	FromBytes            = DefaultSet.FromBytes
 	FromFile             = DefaultSet.FromFile
 	FromCache            = DefaultSet.FromCache
 	RenderTemplateString = DefaultSet.RenderTemplateString


### PR DESCRIPTION
Added a way to go from bytes (which may come from a cache system, or the network), to templates, without having to convert to a string (which is then converted back to bytes).