### PR TITLE
Prevent content inside comments from being parsed in any way.

### DIFF
--- a/lexer.go
+++ b/lexer.go
@@ -348,10 +348,6 @@ outer_loop:
 			}
 		}
 
-		if l.pos < len(l.input) {
-			return l.errorf("Unknown character: %q (%d)", l.peek(), l.peek())
-		}
-
 		break
 	}
 

--- a/tags_comment.go
+++ b/tags_comment.go
@@ -10,7 +10,7 @@ func tagCommentParser(doc *Parser, start *Token, arguments *Parser) (INodeTag, *
 	commentNode := &tagCommentNode{}
 
 	// TODO: Process the endtag's arguments (see django 'comment'-tag documentation)
-	_, _, err := doc.WrapUntilTag("endcomment")
+	err := doc.SkipUntilTag("endcomment")
 	if err != nil {
 		return nil, err
 	}

--- a/template_tests/comment.tpl
+++ b/template_tests/comment.tpl
@@ -1,0 +1,50 @@
+empty single line comment
+{# #}
+
+filled single line comment
+{# testing single line comment #}
+
+filled single line comment with valid tags
+{# testing single line comment {% if thing %}{% endif %} #}
+
+filled single line comment with invalid tags
+{# testing single line comment {% if thing %} #}
+
+filled single line comment with invalid syntax
+{# testing single line comment {% if thing('') %}wow{% endif %} #}
+
+empty block comment
+{% comment %}{% endcomment %}
+
+filled text single line block comment
+{% comment %}filled block comment {% endcomment %}
+
+empty multi line block comment
+{% comment %}
+
+
+{% endcomment %}
+
+block comment with other tags inside of it
+{% comment %}
+  {{ thing_goes_here }}
+  {% if stuff %}do stuff{% endif %}
+{% endcomment %}
+
+block comment with invalid tags inside of it
+{% comment %}
+  {% if thing %}
+{% endcomment %}
+
+block comment with invalid syntax inside of it
+{% comment %}
+  {% thing('') %}
+{% endcomment %}
+
+Regular tags between comments to verify it doesn't break in the lexer
+{% if hello %}
+{% endif %}
+after if
+{% comment %}All done{% endcomment %}
+
+end of file

--- a/template_tests/comment.tpl.out
+++ b/template_tests/comment.tpl.out
@@ -1,0 +1,39 @@
+empty single line comment
+
+
+filled single line comment
+
+
+filled single line comment with valid tags
+
+
+filled single line comment with invalid tags
+
+
+filled single line comment with invalid syntax
+
+
+empty block comment
+
+
+filled text single line block comment
+
+
+empty multi line block comment
+
+
+block comment with other tags inside of it
+
+
+block comment with invalid tags inside of it
+
+
+block comment with invalid syntax inside of it
+
+
+Regular tags between comments to verify it doesn't break in the lexer
+
+after if
+
+
+end of file


### PR DESCRIPTION
Currently contents of comments are being parsed as opposed to just lexed, so things like invalid tokens will break rendering of the page.  This pull prevents any parsing of content inside comments for both character and contextual validity.  Fixes #119 .

With plenty of tests!