### PR TITLE
Expression does not work properly

### DIFF
--- a/template_tests/if.tpl
+++ b/template_tests/if.tpl
@@ -9,6 +9,7 @@
 {% if 5 in simple.intmap %}5 in simple.intmap{% endif %}
 {% if !0.0 %}!0.0{% endif %}
 {% if !0 %}!0{% endif %}
+{% if not complex.post %}true{% else %}false{% endif %}
 {% if simple.number == 43 %}no{% else %}42{% endif %}
 {% if simple.number < 42 %}false{% elif simple.number > 42 %}no{% elif simple.number >= 42 %}yes{% else %}no{% endif %}
 {% if simple.number < 42 %}false{% elif simple.number > 42 %}no{% elif simple.number != 42 %}no{% else %}yes{% endif %}

--- a/template_tests/if.tpl.out
+++ b/template_tests/if.tpl.out
@@ -9,6 +9,7 @@ text field in complex.post
 5 in simple.intmap
 !0.0
 !0
+false
 42
 yes
 yes

--- a/value.go
+++ b/value.go
@@ -240,6 +240,8 @@ func (v *Value) Negate() *Value {
 		return AsValue(v.getResolvedValue().Len() == 0)
 	case reflect.Bool:
 		return AsValue(!v.getResolvedValue().Bool())
+	case reflect.Struct:
+		return AsValue(false)
 	default:
 		logf("Value.IsTrue() not available for type: %s\n", v.getResolvedValue().Kind().String())
 		return AsValue(true)


### PR DESCRIPTION
Tag **if** with negation works incorrectly if it is used to struct.

```go
package main

import (
	"fmt"
	"github.com/flosch/pongo2"
)

type Foo struct{
	Bar string
}

func main() {
	template := "{% if not Foo %}Foo not exists{% endif %} {% if not Bar %}Bar not exists{% endif %}"
	context := pongo2.Context{
		"Foo": Foo{
			Bar: "bar",
		},
	}

	tpl, _ := pongo2.FromString(template)
	res, _ := tpl.Execute(context)

	fmt.Println(res)
}
```

returns

```
Foo not exists Bar not exists
```

I thinks that was not done 013bfa474354404c86f7efb8facf725ec0614b39 (fixed **func IsTrue**, but ignored **func Negate**).

I used commit a269242022ae534b052672d6a9326a40560a63e7 and fixed this bug in pull request.