### PR TITLE
Add split filter builtin.

### DIFF
--- a/filters_builtin.go
+++ b/filters_builtin.go
@@ -73,6 +73,7 @@ func init() {
 	RegisterFilter("removetags", filterRemovetags)
 	RegisterFilter("rjust", filterRjust)
 	RegisterFilter("slice", filterSlice)
+	RegisterFilter("split", filterSplit)
 	RegisterFilter("stringformat", filterStringformat)
 	RegisterFilter("striptags", filterStriptags)
 	RegisterFilter("time", filterDate) // time uses filterDate (same golang-format)
@@ -609,6 +610,12 @@ func filterLinebreaks(in *Value, param *Value) (*Value, *Error) {
 	}
 
 	return AsValue(b.String()), nil
+}
+
+func filterSplit(in *Value, param *Value) (*Value, *Error) {
+	chunks := strings.Split(in.String(), param.String())
+
+	return AsValue(chunks), nil
 }
 
 func filterLinebreaksbr(in *Value, param *Value) (*Value, *Error) {

--- a/template_tests/filters.tpl
+++ b/template_tests/filters.tpl
@@ -176,6 +176,9 @@ floatformat
 join
 {{ simple.misc_list|join:", " }}
 
+split
+{{ "Hello, 99, 3.140000, good"|split:", "|join:", " }}
+
 stringformat
 {{ simple.float|stringformat:"%.2f" }}
 {{ simple.uint|stringformat:"Test: %d" }}

--- a/template_tests/filters.tpl.out
+++ b/template_tests/filters.tpl.out
@@ -176,6 +176,9 @@ floatformat
 join
 Hello, 99, 3.140000, good
 
+split
+Hello, 99, 3.140000, good
+
 stringformat
 3.14
 Test: 8


### PR DESCRIPTION
Provides the inverse of join. This has been a notable missing feature against the join filter.