### PR TITLE
Add mutex to context

### DIFF
--- a/pongo2_template_test.go
+++ b/pongo2_template_test.go
@@ -91,16 +91,16 @@ func init() {
 		panic("cannot write to /tmp/")
 	}
 	f.Write([]byte("Hello from pongo2"))
-	pongo2.DefaultSet.Globals["temp_file"] = f.Name()
+	pongo2.DefaultSet.Globals.Set("temp_file", f.Name())
 }
 
 /*
  * End setup sandbox
  */
 
-var tplContext = pongo2.Context{
+var tplContext = pongo2.NewContext().SetMap(pongo2.ContextMap{
 	"number": 11,
-	"simple": map[string]interface{}{
+	"simple": pongo2.ContextMap{
 		"number":                   42,
 		"name":                     "john doe",
 		"included_file":            "INCLUDES.helper",
@@ -167,7 +167,7 @@ Yep!`,
 			return pongo2.AsValue(s)
 		},
 	},
-	"complex": map[string]interface{}{
+	"complex": pongo2.ContextMap{
 		"is_admin": isAdmin,
 		"post": post{
 			Text:    "<h2>Hello!</h2><p>Welcome to my new blog page. I'm using pongo2 which supports {{ variables }} and {% tags %}.</p>",
@@ -226,11 +226,11 @@ Yep!`,
 			},
 		},
 	},
-}
+})
 
 func TestTemplates(t *testing.T) {
 	// Add a global to the default set
-	pongo2.Globals["this_is_a_global_variable"] = "this is a global text"
+	pongo2.Globals.Set("this_is_a_global_variable", "this is a global text")
 
 	matches, err := filepath.Glob("./template_tests/*.tpl")
 	if err != nil {
@@ -373,8 +373,8 @@ func TestBaseDirectory(t *testing.T) {
 
 	fs := pongo2.MustNewLocalFileSystemLoader("")
 	s := pongo2.NewSet("test set with base directory", fs)
-	s.Globals["base_directory"] = "template_tests/base_dir_test/"
-	if err := fs.SetBaseDir(s.Globals["base_directory"].(string)); err != nil {
+	s.Globals.Set("base_directory", "template_tests/base_dir_test/")
+	if err := fs.SetBaseDir(s.Globals.GetString("base_directory")); err != nil {
 		t.Fatal(err)
 	}
 

--- a/tags_block.go
+++ b/tags_block.go
@@ -39,10 +39,10 @@ func (node *tagBlockNode) Execute(ctx *ExecutionContext, writer TemplateWriter) 
 	}
 
 	blockWrapper := blockWrappers[lenBlockWrappers-1]
-	ctx.Private["block"] = tagBlockInformation{
+	ctx.Private.Set("block", tagBlockInformation{
 		ctx:      ctx,
 		wrappers: blockWrappers[0 : lenBlockWrappers-1],
-	}
+	})
 	err := blockWrapper.Execute(ctx, writer)
 	if err != nil {
 		return err
@@ -64,10 +64,10 @@ func (t tagBlockInformation) Super() string {
 	}
 
 	superCtx := NewChildExecutionContext(t.ctx)
-	superCtx.Private["block"] = tagBlockInformation{
+	superCtx.Private.Set("block", tagBlockInformation{
 		ctx:      t.ctx,
 		wrappers: t.wrappers[0 : lenWrappers-1],
-	}
+	})
 
 	blockWrapper := t.wrappers[lenWrappers-1]
 	buf := bytes.NewBufferString("")

--- a/tags_cycle.go
+++ b/tags_cycle.go
@@ -53,7 +53,7 @@ func (node *tagCycleNode) Execute(ctx *ExecutionContext, writer TemplateWriter) 
 		}
 
 		if node.asName != "" {
-			ctx.Private[node.asName] = cycleValue
+			ctx.Private.Set(node.asName, cycleValue)
 		}
 		if !node.silent {
 			writer.WriteString(val.String())

--- a/tags_for.go
+++ b/tags_for.go
@@ -24,7 +24,7 @@ type tagForLoopInformation struct {
 func (node *tagForNode) Execute(ctx *ExecutionContext, writer TemplateWriter) (forError *Error) {
 	// Backup forloop (as parentloop in public context), key-name and value-name
 	forCtx := NewChildExecutionContext(ctx)
-	parentloop := forCtx.Private["forloop"]
+	parentloop := forCtx.Private.Get("forloop")
 
 	// Create loop struct
 	loopInfo := &tagForLoopInformation{
@@ -37,7 +37,7 @@ func (node *tagForNode) Execute(ctx *ExecutionContext, writer TemplateWriter) (f
 	}
 
 	// Register loopInfo in public context
-	forCtx.Private["forloop"] = loopInfo
+	forCtx.Private.Set("forloop", loopInfo)
 
 	obj, err := node.objectEvaluator.Evaluate(forCtx)
 	if err != nil {
@@ -48,9 +48,9 @@ func (node *tagForNode) Execute(ctx *ExecutionContext, writer TemplateWriter) (f
 		// There's something to iterate over (correct type and at least 1 item)
 
 		// Update loop infos and public context
-		forCtx.Private[node.key] = key
+		forCtx.Private.Set(node.key, key)
 		if value != nil {
-			forCtx.Private[node.value] = value
+			forCtx.Private.Set(node.value, value)
 		}
 		loopInfo.Counter = idx + 1
 		loopInfo.Counter0 = idx

--- a/tags_import.go
+++ b/tags_import.go
@@ -13,9 +13,9 @@ type tagImportNode struct {
 func (node *tagImportNode) Execute(ctx *ExecutionContext, writer TemplateWriter) *Error {
 	for name, macro := range node.macros {
 		func(name string, macro *tagMacroNode) {
-			ctx.Private[name] = func(args ...*Value) *Value {
+			ctx.Private.Set(name, func(args ...*Value) *Value {
 				return macro.call(ctx, args...)
-			}
+			})
 		}(name, macro)
 	}
 	return nil

--- a/tags_include.go
+++ b/tags_include.go
@@ -12,7 +12,7 @@ type tagIncludeNode struct {
 
 func (node *tagIncludeNode) Execute(ctx *ExecutionContext, writer TemplateWriter) *Error {
 	// Building the context for the template
-	includeCtx := make(Context)
+	includeCtx := NewContext()
 
 	// Fill the context with all data from the parent
 	if !node.only {
@@ -26,7 +26,7 @@ func (node *tagIncludeNode) Execute(ctx *ExecutionContext, writer TemplateWriter
 		if err != nil {
 			return err
 		}
-		includeCtx[key] = val
+		includeCtx.Set(key, val)
 	}
 
 	// Execute the template

--- a/tags_macro.go
+++ b/tags_macro.go
@@ -16,20 +16,20 @@ type tagMacroNode struct {
 }
 
 func (node *tagMacroNode) Execute(ctx *ExecutionContext, writer TemplateWriter) *Error {
-	ctx.Private[node.name] = func(args ...*Value) *Value {
+	ctx.Private.Set(node.name, func(args ...*Value) *Value {
 		return node.call(ctx, args...)
-	}
+	})
 
 	return nil
 }
 
 func (node *tagMacroNode) call(ctx *ExecutionContext, args ...*Value) *Value {
-	argsCtx := make(Context)
+	argsCtx := NewContext()
 
 	for k, v := range node.args {
 		if v == nil {
 			// User did not provided a default value
-			argsCtx[k] = nil
+			argsCtx.Set(k, nil)
 		} else {
 			// Evaluate the default value
 			valueExpr, err := v.Evaluate(ctx)
@@ -38,7 +38,7 @@ func (node *tagMacroNode) call(ctx *ExecutionContext, args ...*Value) *Value {
 				return AsSafeValue(err.Error())
 			}
 
-			argsCtx[k] = valueExpr
+			argsCtx.Set(k, valueExpr)
 		}
 	}
 
@@ -58,7 +58,7 @@ func (node *tagMacroNode) call(ctx *ExecutionContext, args ...*Value) *Value {
 	macroCtx.Private.Update(argsCtx)
 
 	for idx, argValue := range args {
-		macroCtx.Private[node.argsOrder[idx]] = argValue.Interface()
+		macroCtx.Private.Set(node.argsOrder[idx], argValue.Interface())
 	}
 
 	var b bytes.Buffer

--- a/tags_set.go
+++ b/tags_set.go
@@ -12,7 +12,7 @@ func (node *tagSetNode) Execute(ctx *ExecutionContext, writer TemplateWriter) *E
 		return err
 	}
 
-	ctx.Private[node.name] = value
+	ctx.Private.Set(node.name, value)
 	return nil
 }
 

--- a/tags_ssi.go
+++ b/tags_ssi.go
@@ -13,7 +13,7 @@ type tagSSINode struct {
 func (node *tagSSINode) Execute(ctx *ExecutionContext, writer TemplateWriter) *Error {
 	if node.template != nil {
 		// Execute the template within the current context
-		includeCtx := make(Context)
+		includeCtx := NewContext()
 		includeCtx.Update(ctx.Public)
 		includeCtx.Update(ctx.Private)
 

--- a/tags_widthratio.go
+++ b/tags_widthratio.go
@@ -33,7 +33,7 @@ func (node *tagWidthratioNode) Execute(ctx *ExecutionContext, writer TemplateWri
 	if node.ctxName == "" {
 		writer.WriteString(fmt.Sprintf("%d", value))
 	} else {
-		ctx.Private[node.ctxName] = value
+		ctx.Private.Set(node.ctxName, value)
 	}
 
 	return nil

--- a/tags_with.go
+++ b/tags_with.go
@@ -15,7 +15,7 @@ func (node *tagWithNode) Execute(ctx *ExecutionContext, writer TemplateWriter) *
 		if err != nil {
 			return err
 		}
-		withctx.Private[key] = val
+		withctx.Private.Set(key, val)
 	}
 
 	return node.wrapper.Execute(withctx, writer)

--- a/template_sets.go
+++ b/template_sets.go
@@ -30,7 +30,7 @@ type TemplateSet struct {
 	loader TemplateLoader
 
 	// Globals will be provided to all templates created within this template set
-	Globals Context
+	Globals *Context
 
 	// If debug is true (default false), ExecutionContext.Logf() will work and output
 	// to STDOUT. Furthermore, FromCache() won't cache the templates.
@@ -60,7 +60,7 @@ func NewSet(name string, loader TemplateLoader) *TemplateSet {
 	return &TemplateSet{
 		name:          name,
 		loader:        loader,
-		Globals:       make(Context),
+		Globals:       NewContext(),
 		bannedTags:    make(map[string]bool),
 		bannedFilters: make(map[string]bool),
 		templateCache: make(map[string]*Template),
@@ -186,7 +186,7 @@ func (set *TemplateSet) FromFile(filename string) (*Template, error) {
 
 // RenderTemplateString is a shortcut and renders a template string directly.
 // Panics when providing a malformed template or an error occurs during execution.
-func (set *TemplateSet) RenderTemplateString(s string, ctx Context) string {
+func (set *TemplateSet) RenderTemplateString(s string, ctx *Context) string {
 	set.firstTemplateCreated = true
 
 	tpl := Must(set.FromString(s))
@@ -199,7 +199,7 @@ func (set *TemplateSet) RenderTemplateString(s string, ctx Context) string {
 
 // RenderTemplateBytes is a shortcut and renders template bytes directly.
 // Panics when providing a malformed template or an error occurs during execution.
-func (set *TemplateSet) RenderTemplateBytes(b []byte, ctx Context) string {
+func (set *TemplateSet) RenderTemplateBytes(b []byte, ctx *Context) string {
 	set.firstTemplateCreated = true
 
 	tpl := Must(set.FromBytes(b))
@@ -212,7 +212,7 @@ func (set *TemplateSet) RenderTemplateBytes(b []byte, ctx Context) string {
 
 // RenderTemplateFile is a shortcut and renders a template file directly.
 // Panics when providing a malformed template or an error occurs during execution.
-func (set *TemplateSet) RenderTemplateFile(fn string, ctx Context) string {
+func (set *TemplateSet) RenderTemplateFile(fn string, ctx *Context) string {
 	set.firstTemplateCreated = true
 
 	tpl := Must(set.FromFile(fn))

--- a/variable.go
+++ b/variable.go
@@ -235,10 +235,10 @@ func (vr *variableResolver) resolve(ctx *ExecutionContext) (*Value, error) {
 			// We're looking up the first part of the variable.
 			// First we're having a look in our private
 			// context (e. g. information provided by tags, like the forloop)
-			val, inPrivate := ctx.Private[vr.parts[0].s]
+			val, inPrivate := ctx.Private.context[vr.parts[0].s]
 			if !inPrivate {
 				// Nothing found? Then have a final lookup in the public context
-				val = ctx.Public[vr.parts[0].s]
+				val = ctx.Public.Get(vr.parts[0].s)
 			}
 			current = reflect.ValueOf(val) // Get the initial value
 		} else {
@@ -336,7 +336,7 @@ func (vr *variableResolver) resolve(ctx *ExecutionContext) (*Value, error) {
 
 			// If an implicit ExecCtx is needed
 			if t.NumIn() > 0 && t.In(0) == typeOfExecCtxPtr {
-				 currArgs = append([]functionCallArgument{executionCtxEval{}}, currArgs...)
+				currArgs = append([]functionCallArgument{executionCtxEval{}}, currArgs...)
 			}
 
 			// Input arguments


### PR DESCRIPTION
This pull request adds a mutex to the Context type and introduces `NewContext()` for creating a new Context and a `Set` method for setting values in a thread-safe way.

It solves issue #139 here and also makes [this](https://github.com/xyproto/algernon/blob/7506d96709dd1d65d8866b4ddd2cf66be4e827fa/pongo_test.go) test pass, that previously failed.

The downside is that existing code that modifies Context directly might have to be modified.
