### PR TITLE
changes custom error type to include original error

### DIFF
--- a/context.go
+++ b/context.go
@@ -1,6 +1,7 @@
 package pongo2
 
 import (
+	"errors"
 	"fmt"
 	"regexp"
 )
@@ -24,8 +25,8 @@ func (c Context) checkForValidIdentifiers() *Error {
 	for k, v := range c {
 		if !reIdentifiers.MatchString(k) {
 			return &Error{
-				Sender:   "checkForValidIdentifiers",
-				ErrorMsg: fmt.Sprintf("Context-key '%s' (value: '%+v') is not a valid identifier.", k, v),
+				Sender:    "checkForValidIdentifiers",
+				OrigError: fmt.Errorf("Context-key '%s' (value: '%+v') is not a valid identifier.", k, v),
 			}
 		}
 	}
@@ -110,13 +111,13 @@ func (ctx *ExecutionContext) Error(msg string, token *Token) *Error {
 		col = token.Col
 	}
 	return &Error{
-		Template: ctx.template,
-		Filename: filename,
-		Line:     line,
-		Column:   col,
-		Token:    token,
-		Sender:   "execution",
-		ErrorMsg: msg,
+		Template:  ctx.template,
+		Filename:  filename,
+		Line:      line,
+		Column:    col,
+		Token:     token,
+		Sender:    "execution",
+		OrigError: errors.New(msg),
 	}
 }
 

--- a/error.go
+++ b/error.go
@@ -13,13 +13,13 @@ import (
 // a filter, make Sender equals 'filter:yourfilter'; same goes for tags: 'tag:mytag').
 // It's okay if you only fill in ErrorMsg if you don't have any other details at hand.
 type Error struct {
-	Template *Template
-	Filename string
-	Line     int
-	Column   int
-	Token    *Token
-	Sender   string
-	ErrorMsg string
+	Template  *Template
+	Filename  string
+	Line      int
+	Column    int
+	Token     *Token
+	Sender    string
+	OrigError error
 }
 
 func (e *Error) updateFromTokenIfNeeded(template *Template, t *Token) *Error {
@@ -54,7 +54,7 @@ func (e *Error) Error() string {
 		}
 	}
 	s += "] "
-	s += e.ErrorMsg
+	s += e.OrigError.Error()
 	return s
 }
 

--- a/filters.go
+++ b/filters.go
@@ -51,8 +51,8 @@ func ApplyFilter(name string, value *Value, param *Value) (*Value, *Error) {
 	fn, existing := filters[name]
 	if !existing {
 		return nil, &Error{
-			Sender:   "applyfilter",
-			ErrorMsg: fmt.Sprintf("Filter with name '%s' not found.", name),
+			Sender:    "applyfilter",
+			OrigError: fmt.Errorf("Filter with name '%s' not found.", name),
 		}
 	}
 

--- a/filters_builtin.go
+++ b/filters_builtin.go
@@ -27,6 +27,7 @@ package pongo2
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"math/rand"
 	"net/url"
@@ -553,8 +554,8 @@ func filterDate(in *Value, param *Value) (*Value, *Error) {
 	t, isTime := in.Interface().(time.Time)
 	if !isTime {
 		return nil, &Error{
-			Sender:   "filter:date",
-			ErrorMsg: "Filter input argument must be of type 'time.Time'.",
+			Sender:    "filter:date",
+			OrigError: errors.New("Filter input argument must be of type 'time.Time'."),
 		}
 	}
 	return AsValue(t.Format(param.String())), nil
@@ -752,8 +753,8 @@ func filterPluralize(in *Value, param *Value) (*Value, *Error) {
 			endings := strings.Split(param.String(), ",")
 			if len(endings) > 2 {
 				return nil, &Error{
-					Sender:   "filter:pluralize",
-					ErrorMsg: "You cannot pass more than 2 arguments to filter 'pluralize'.",
+					Sender:    "filter:pluralize",
+					OrigError: errors.New("You cannot pass more than 2 arguments to filter 'pluralize'."),
 				}
 			}
 			if len(endings) == 1 {
@@ -778,8 +779,8 @@ func filterPluralize(in *Value, param *Value) (*Value, *Error) {
 		return AsValue(""), nil
 	}
 	return nil, &Error{
-		Sender:   "filter:pluralize",
-		ErrorMsg: "Filter 'pluralize' does only work on numbers.",
+		Sender:    "filter:pluralize",
+		OrigError: errors.New("Filter 'pluralize' does only work on numbers."),
 	}
 }
 
@@ -812,8 +813,8 @@ func filterSlice(in *Value, param *Value) (*Value, *Error) {
 	comp := strings.Split(param.String(), ":")
 	if len(comp) != 2 {
 		return nil, &Error{
-			Sender:   "filter:slice",
-			ErrorMsg: "Slice string must have the format 'from:to' [from/to can be omitted, but the ':' is required]",
+			Sender:    "filter:slice",
+			OrigError: errors.New("Slice string must have the format 'from:to' [from/to can be omitted, but the ':' is required]"),
 		}
 	}
 
@@ -874,14 +875,14 @@ func filterYesno(in *Value, param *Value) (*Value, *Error) {
 	if len(paramString) > 0 {
 		if len(customChoices) > 3 {
 			return nil, &Error{
-				Sender:   "filter:yesno",
-				ErrorMsg: fmt.Sprintf("You cannot pass more than 3 options to the 'yesno'-filter (got: '%s').", paramString),
+				Sender:    "filter:yesno",
+				OrigError: fmt.Errorf("You cannot pass more than 3 options to the 'yesno'-filter (got: '%s').", paramString),
 			}
 		}
 		if len(customChoices) < 2 {
 			return nil, &Error{
-				Sender:   "filter:yesno",
-				ErrorMsg: fmt.Sprintf("You must pass either no or at least 2 arguments to the 'yesno'-filter (got: '%s').", paramString),
+				Sender:    "filter:yesno",
+				OrigError: fmt.Errorf("You must pass either no or at least 2 arguments to the 'yesno'-filter (got: '%s').", paramString),
 			}
 		}
 

--- a/lexer.go
+++ b/lexer.go
@@ -1,6 +1,7 @@
 package pongo2
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 	"unicode/utf8"
@@ -111,11 +112,11 @@ func lex(name string, input string) ([]*Token, *Error) {
 	if l.errored {
 		errtoken := l.tokens[len(l.tokens)-1]
 		return nil, &Error{
-			Filename: name,
-			Line:     errtoken.Line,
-			Column:   errtoken.Col,
-			Sender:   "lexer",
-			ErrorMsg: errtoken.Val,
+			Filename:  name,
+			Line:      errtoken.Line,
+			Column:    errtoken.Col,
+			Sender:    "lexer",
+			OrigError: errors.New(errtoken.Val),
 		}
 	}
 	return l.tokens, nil

--- a/parser.go
+++ b/parser.go
@@ -1,6 +1,7 @@
 package pongo2
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 )
@@ -195,13 +196,13 @@ func (p *Parser) Error(msg string, token *Token) *Error {
 		col = token.Col
 	}
 	return &Error{
-		Template: p.template,
-		Filename: p.name,
-		Sender:   "parser",
-		Line:     line,
-		Column:   col,
-		Token:    token,
-		ErrorMsg: msg,
+		Template:  p.template,
+		Filename:  p.name,
+		Sender:    "parser",
+		Line:      line,
+		Column:    col,
+		Token:     token,
+		OrigError: errors.New(msg),
 	}
 }
 

--- a/tags_ssi.go
+++ b/tags_ssi.go
@@ -46,8 +46,8 @@ func tagSSIParser(doc *Parser, start *Token, arguments *Parser) (INodeTag, *Erro
 			buf, err := ioutil.ReadFile(doc.template.set.resolveFilename(doc.template, fileToken.Val))
 			if err != nil {
 				return nil, (&Error{
-					Sender:   "tag:ssi",
-					ErrorMsg: err.Error(),
+					Sender:    "tag:ssi",
+					OrigError: err,
 				}).updateFromTokenIfNeeded(doc.template, fileToken)
 			}
 			SSINode.content = string(buf)

--- a/template.go
+++ b/template.go
@@ -112,9 +112,9 @@ func (tpl *Template) execute(context Context, writer TemplateWriter) error {
 				_, has := tpl.exportedMacros[k]
 				if has {
 					return &Error{
-						Filename: tpl.name,
-						Sender:   "execution",
-						ErrorMsg: fmt.Sprintf("Context key name '%s' clashes with macro '%s'.", k, k),
+						Filename:  tpl.name,
+						Sender:    "execution",
+						OrigError: fmt.Errorf("Context key name '%s' clashes with macro '%s'.", k, k),
 					}
 				}
 			}

--- a/template_sets.go
+++ b/template_sets.go
@@ -167,17 +167,17 @@ func (set *TemplateSet) FromFile(filename string) (*Template, error) {
 	fd, err := set.loader.Get(set.resolveFilename(nil, filename))
 	if err != nil {
 		return nil, &Error{
-			Filename: filename,
-			Sender:   "fromfile",
-			ErrorMsg: err.Error(),
+			Filename:  filename,
+			Sender:    "fromfile",
+			OrigError: err,
 		}
 	}
 	buf, err := ioutil.ReadAll(fd)
 	if err != nil {
 		return nil, &Error{
-			Filename: filename,
-			Sender:   "fromfile",
-			ErrorMsg: err.Error(),
+			Filename:  filename,
+			Sender:    "fromfile",
+			OrigError: err,
 		}
 	}
 


### PR DESCRIPTION
It is a **breaking** change, so please review it carefully.

In most cases, it is useful to get the original error value returns from pongo2 to be able to handle it properly.

One more problem, I read pongo2 codes and see many panic usages should be replaced by returning error value, but it will be a drastically change, so I don't do it in this PR.