### PR TITLE
Adding support for single quotes in variables, functions and tags

### DIFF
--- a/lexer.go
+++ b/lexer.go
@@ -330,7 +330,7 @@ outer_loop:
 			return l.stateIdentifier
 		case l.accept(tokenDigits):
 			return l.stateNumber
-		case l.accept(`"`):
+		case l.accept(`"'`):
 			return l.stateString
 		}
 
@@ -396,9 +396,10 @@ func (l *lexer) stateNumber() lexerStateFn {
 }
 
 func (l *lexer) stateString() lexerStateFn {
+	quotationMark := l.value()
 	l.ignore()
 	l.startcol-- // we're starting the position at the first "
-	for !l.accept(`"`) {
+	for !l.accept(quotationMark) {
 		switch l.next() {
 		case '\\':
 			// escape sequence

--- a/template_tests/quotes.tpl
+++ b/template_tests/quotes.tpl
@@ -1,0 +1,15 @@
+Variables
+{{ "hello" }}
+{{ 'hello' }}
+{{ "hell'o" }}
+
+Filters
+{{ 'Test'|slice:'1:3' }}
+{{ '<div class=\"foo\"><ul class=\"foo\"><li class=\"foo\"><p class=\"foo\">This is a long test which will be cutted after some chars.</p></li></ul></div>'|truncatechars_html:25 }}
+{{ '<a name="link"><p>This </a>is a long test which will be cutted after some chars.</p>'|truncatechars_html:25 }}
+
+Tags
+{% if 'Text' in complex.post %}text field in complex.post{% endif %}
+
+Functions
+{{ simple.func_variadic('hello') }}

--- a/template_tests/quotes.tpl.out
+++ b/template_tests/quotes.tpl.out
@@ -1,0 +1,15 @@
+Variables
+hello
+hello
+hell&#39;o
+
+Filters
+es
+<div class="foo"><ul class="foo"><li class="foo"><p class="foo">This is a long test wh...</p></li></ul></div>
+<a name="link"><p>This </a>is a long test wh...</p>
+
+Tags
+text field in complex.post
+
+Functions
+hello


### PR DESCRIPTION
Adding support for single quotes to allow inclusion of templates in the json files or in other places where we have to use double quotes or nested double quotes.
For example in this case where value is a string representing json
```
{
"key": "\"{{'hello'}}\""
}
```
Or makes it easier to read in cases where double quotes have been already used:
`val := "{{'hello'}}"`

