### PR TITLE
Only execute right side of or/and when necessary

### DIFF
--- a/parser_expression.go
+++ b/parser_expression.go
@@ -136,15 +136,27 @@ func (expr *Expression) Evaluate(ctx *ExecutionContext) (*Value, *Error) {
 		return nil, err
 	}
 	if expr.expr2 != nil {
-		v2, err := expr.expr2.Evaluate(ctx)
-		if err != nil {
-			return nil, err
-		}
 		switch expr.opToken.Val {
 		case "and", "&&":
-			return AsValue(v1.IsTrue() && v2.IsTrue()), nil
+			if !v1.IsTrue() {
+				return AsValue(false), nil
+			} else {
+				v2, err := expr.expr2.Evaluate(ctx)
+				if err != nil {
+					return nil, err
+				}
+				return AsValue(v2.IsTrue()), nil
+			}
 		case "or", "||":
-			return AsValue(v1.IsTrue() || v2.IsTrue()), nil
+			if v1.IsTrue() {
+				return AsValue(true), nil
+			} else {
+				v2, err := expr.expr2.Evaluate(ctx)
+				if err != nil {
+					return nil, err
+				}
+				return AsValue(v2.IsTrue()), nil
+			}
 		default:
 			return nil, ctx.Error(fmt.Sprintf("unimplemented: %s", expr.opToken.Val), expr.opToken)
 		}


### PR DESCRIPTION
I have a function that checks permissions and takes user as an argument. Because functions cannot be called with `nil` arguments for some reason, I must first check user:
`{% if user and HasPermissions(user) %}`
As this was implemented now `and` did not help because both sides were evaluated.

This should behave as all programming languages and only evaluate left side when other side is not necessary.