### PR TITLE
fix 'map[interface{}]interface{} sorted not work' bug

### DIFF
--- a/value.go
+++ b/value.go
@@ -511,7 +511,7 @@ func (vl valuesList) Less(i, j int) bool {
 	case vi.IsFloat() && vj.IsFloat():
 		return vi.Float() < vj.Float()
 	default:
-		return vi.String() < vj.String()
+		return fmt.Sprint(vi.Interface()) < fmt.Sprint(vi.Interface())
 	}
 }
 


### PR DESCRIPTION
when value is interface{}, vi.String() return `interface{}` string, `sorted` not work

use `fmt.Sprint(vi.Interface())` replace `vi.String()`