### PR TITLE
Enable Golang Modules (https://github.com/golang/go/wiki/Modules)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text eol=lf

--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ tpl-error.out
 /profile
 /coverage.out
 /pongo2_internal_test.ignore
+go.sum

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: go
-
 os:
   - windows
   - linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,15 @@
 language: go
 
+os:
+  - windows
+  - linux
+  - osx
 go:
-  - 1.7
+  - 1.11.4
   - tip
 install:
-  - go get golang.org/x/tools/cmd/cover
+  - go mod download
   - go get github.com/mattn/goveralls
-  - go get gopkg.in/check.v1
-  - go get github.com/juju/errors
 script:
   - go test -v -covermode=count -coverprofile=coverage.out -bench . -cpu 1,4
   - '[ "${TRAVIS_PULL_REQUEST}" = "false" ] && $HOME/gopath/bin/goveralls -coverprofile=coverage.out -service=travis-ci -repotoken $COVERALLS_TOKEN || true'

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,9 @@ os:
   - osx
 go:
   - 1.11.4
-  - tip
+env:
+  global:
+    - GO111MODULE=on
 install:
   - go mod download
   - go get github.com/mattn/goveralls

--- a/AUTHORS
+++ b/AUTHORS
@@ -6,5 +6,6 @@ Contributors (in no specific order):
 
 * @romanoaugusto88
 * @vitalbh
+* @blaubaer
 
 Feel free to add yourself to the list or to modify your entry if you did a contribution.

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,13 @@
+module github.com/flosch/pongo2
+
+require (
+	github.com/go-check/check v1.0.0-20180628173108-788fd7840127
+	github.com/juju/errors v0.0.0-20181118221551-089d3ea4e4d5
+	github.com/juju/loggo v0.0.0-20180524022052-584905176618 // indirect
+	github.com/juju/testing v0.0.0-20180920084828-472a3e8b2073 // indirect
+	github.com/kr/pretty v0.1.0 // indirect
+	github.com/mattn/goveralls v0.0.2 // indirect
+	golang.org/x/tools v0.0.0-20181221001348-537d06c36207 // indirect
+	gopkg.in/mgo.v2 v2.0.0-20180705113604-9856a29383ce // indirect
+	gopkg.in/yaml.v2 v2.2.2 // indirect
+)

--- a/pongo2_test.go
+++ b/pongo2_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/flosch/pongo2"
-	. "gopkg.in/check.v1"
+	. "github.com/go-check/check"
 )
 
 // Hook up gocheck into the "go test" runner.
@@ -43,7 +43,7 @@ func (s *TestSuite) TestMisc(c *C) {
 	c.Check(
 		func() { pongo2.Must(testSuite2.FromFile("template_tests/inheritance/base2.tpl")) },
 		PanicMatches,
-		`\[Error \(where: fromfile\) in .*template_tests/inheritance/doesnotexist.tpl | Line 1 Col 12 near 'doesnotexist.tpl'\] open .*template_tests/inheritance/doesnotexist.tpl: no such file or directory`,
+		`\[Error \(where: fromfile\) in .*template_tests[/\\]inheritance[/\\]doesnotexist.tpl | Line 1 Col 12 near 'doesnotexist.tpl'\] open .*template_tests[/\\]inheritance[/\\]doesnotexist.tpl: no such file or directory`,
 	)
 
 	// Context


### PR DESCRIPTION
1. Enable Golang Modules (https://github.com/golang/go/wiki/Modules) for better portability and to get rid of the weird vendors etc. folder structures
2. Make tests platform independent (no running on Linux, MacOS and Windows) - this includes line endings to always `lf`
3. Use sub-Runs in tests instead of Logf for better visibility if something happens
4. `go fmt` changed files