### PR TITLE
Fix github.com/go-check/check version number

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/flosch/pongo2
 
 require (
-	github.com/go-check/check v1.0.0-20180628173108-788fd7840127
+	github.com/go-check/check v0.0.0-20180628173108-788fd7840127
 	github.com/juju/errors v0.0.0-20181118221551-089d3ea4e4d5
 	github.com/juju/loggo v0.0.0-20180524022052-584905176618 // indirect
 	github.com/juju/testing v0.0.0-20180920084828-472a3e8b2073 // indirect


### PR DESCRIPTION
This is an untagged commit ID, so the version should start with "v0.0.0" instead of "v1.0.0".

Fixes #214