### PR TITLE
Add filter `e` (alias of `escape`)

### DIFF
--- a/docs/filters.md
+++ b/docs/filters.md
@@ -6,6 +6,7 @@ TODO:
 Implemented filters so far which needs documentation:
 
 * escape
+* e (alias of `escape`)
 * safe
 * escapejs
 * add

--- a/filters_builtin.go
+++ b/filters_builtin.go
@@ -43,6 +43,7 @@ func init() {
 	rand.Seed(time.Now().Unix())
 
 	RegisterFilter("escape", filterEscape)
+	RegisterFilter("e", filterEscape)	// alias of `escape`
 	RegisterFilter("safe", filterSafe)
 	RegisterFilter("escapejs", filterEscapejs)
 

--- a/template_tests/filters.tpl
+++ b/template_tests/filters.tpl
@@ -46,6 +46,7 @@ safe
 
 escape
 {{ "<script>"|safe|escape }}
+{{ "<script>"|safe|e }}
 
 title
 {{ ""|title }}

--- a/template_tests/filters.tpl.out
+++ b/template_tests/filters.tpl.out
@@ -46,6 +46,7 @@ safe
 
 escape
 &lt;script&gt;
+&lt;script&gt;
 
 title
 


### PR DESCRIPTION
Jinja2 has filter `e` which is an alias of `escape`, it's shorter and easier to write. Hope we can have it too in pongo2. :)
FYI: https://jinja.palletsprojects.com/en/2.11.x/templates/#escape