### PR TITLE
Expose some fields and methods for implementing custom tags

### DIFF
--- a/context.go
+++ b/context.go
@@ -133,5 +133,5 @@ func (ctx *ExecutionContext) OrigError(err error, token *Token) *Error {
 }
 
 func (ctx *ExecutionContext) Logf(format string, args ...interface{}) {
-	ctx.template.set.logf(format, args...)
+	ctx.template.Set.logf(format, args...)
 }

--- a/context.go
+++ b/context.go
@@ -64,7 +64,7 @@ func (c Context) Update(other Context) Context {
 // To create your own execution context within tags, use the
 // NewChildExecutionContext(parent) function.
 type ExecutionContext struct {
-	template *Template
+	Template *Template
 
 	Autoescape bool
 	Public     Context
@@ -83,7 +83,7 @@ func newExecutionContext(tpl *Template, ctx Context) *ExecutionContext {
 	privateCtx["pongo2"] = pongo2MetaContext
 
 	return &ExecutionContext{
-		template: tpl,
+		Template: tpl,
 
 		Public:     ctx,
 		Private:    privateCtx,
@@ -93,7 +93,7 @@ func newExecutionContext(tpl *Template, ctx Context) *ExecutionContext {
 
 func NewChildExecutionContext(parent *ExecutionContext) *ExecutionContext {
 	newctx := &ExecutionContext{
-		template: parent.template,
+		Template: parent.Template,
 
 		Public:     parent.Public,
 		Private:    make(Context),
@@ -112,7 +112,7 @@ func (ctx *ExecutionContext) Error(msg string, token *Token) *Error {
 }
 
 func (ctx *ExecutionContext) OrigError(err error, token *Token) *Error {
-	filename := ctx.template.name
+	filename := ctx.Template.name
 	var line, col int
 	if token != nil {
 		// No tokens available
@@ -122,7 +122,7 @@ func (ctx *ExecutionContext) OrigError(err error, token *Token) *Error {
 		col = token.Col
 	}
 	return &Error{
-		Template:  ctx.template,
+		Template:  ctx.Template,
 		Filename:  filename,
 		Line:      line,
 		Column:    col,
@@ -133,5 +133,5 @@ func (ctx *ExecutionContext) OrigError(err error, token *Token) *Error {
 }
 
 func (ctx *ExecutionContext) Logf(format string, args ...interface{}) {
-	ctx.template.Set.logf(format, args...)
+	ctx.Template.Set.logf(format, args...)
 }

--- a/error.go
+++ b/error.go
@@ -66,7 +66,7 @@ func (e *Error) RawLine() (line string, available bool, outErr error) {
 
 	filename := e.Filename
 	if e.Template != nil {
-		filename = e.Template.set.resolveFilename(e.Template, e.Filename)
+		filename = e.Template.Set.resolveFilename(e.Template, e.Filename)
 	}
 	file, err := os.Open(filename)
 	if err != nil {

--- a/error.go
+++ b/error.go
@@ -66,7 +66,7 @@ func (e *Error) RawLine() (line string, available bool, outErr error) {
 
 	filename := e.Filename
 	if e.Template != nil {
-		filename = e.Template.Set.resolveFilename(e.Template, e.Filename)
+		filename = e.Template.Set.ResolveFilename(e.Template, e.Filename)
 	}
 	file, err := os.Open(filename)
 	if err != nil {

--- a/filters.go
+++ b/filters.go
@@ -96,7 +96,7 @@ func (fc *filterCall) Execute(v *Value, ctx *ExecutionContext) (*Value, *Error) 
 
 	filteredValue, err := fc.filterFunc(v, param)
 	if err != nil {
-		return nil, err.updateFromTokenIfNeeded(ctx.template, fc.token)
+		return nil, err.updateFromTokenIfNeeded(ctx.Template, fc.token)
 	}
 	return filteredValue, nil
 }

--- a/parser.go
+++ b/parser.go
@@ -35,7 +35,7 @@ type Parser struct {
 
 	// if the parser parses a template document, here will be
 	// a reference to it (needed to access the template through Tags)
-	template *Template
+	Template *Template
 }
 
 // Creates a new parser to parse tokens.
@@ -45,7 +45,7 @@ func newParser(name string, tokens []*Token, template *Template) *Parser {
 	p := &Parser{
 		name:     name,
 		tokens:   tokens,
-		template: template,
+		Template: template,
 	}
 	if len(tokens) > 0 {
 		p.lastToken = tokens[len(tokens)-1]
@@ -197,7 +197,7 @@ func (p *Parser) Error(msg string, token *Token) *Error {
 		col = token.Col
 	}
 	return &Error{
-		Template:  p.template,
+		Template:  p.Template,
 		Filename:  p.name,
 		Sender:    "parser",
 		Line:      line,
@@ -240,7 +240,7 @@ func (p *Parser) WrapUntilTag(names ...string) (*NodeWrapper, *Parser, *Error) {
 						if p.Match(TokenSymbol, "%}") != nil {
 							// Okay, end the wrapping here
 							wrapper.Endtag = tagIdent.Val
-							return wrapper, newParser(p.template.name, tagArgs, p.template), nil
+							return wrapper, newParser(p.Template.name, tagArgs, p.Template), nil
 						}
 						t := p.Current()
 						p.Consume()

--- a/tags.go
+++ b/tags.go
@@ -103,7 +103,7 @@ func (p *Parser) parseTagElement() (INodeTag, *Error) {
 	}
 
 	// Check sandbox tag restriction
-	if _, isBanned := p.Template.set.bannedTags[tokenName.Val]; isBanned {
+	if _, isBanned := p.Template.Set.bannedTags[tokenName.Val]; isBanned {
 		return nil, p.Error(fmt.Sprintf("Usage of tag '%s' is not allowed (sandbox restriction active).", tokenName.Val), tokenName)
 	}
 

--- a/tags.go
+++ b/tags.go
@@ -103,7 +103,7 @@ func (p *Parser) parseTagElement() (INodeTag, *Error) {
 	}
 
 	// Check sandbox tag restriction
-	if _, isBanned := p.template.set.bannedTags[tokenName.Val]; isBanned {
+	if _, isBanned := p.Template.set.bannedTags[tokenName.Val]; isBanned {
 		return nil, p.Error(fmt.Sprintf("Usage of tag '%s' is not allowed (sandbox restriction active).", tokenName.Val), tokenName)
 	}
 
@@ -121,13 +121,13 @@ func (p *Parser) parseTagElement() (INodeTag, *Error) {
 
 	p.Match(TokenSymbol, "%}")
 
-	argParser := newParser(p.name, argsToken, p.template)
+	argParser := newParser(p.name, argsToken, p.Template)
 	if len(argsToken) == 0 {
 		// This is done to have nice EOF error messages
 		argParser.lastToken = tokenName
 	}
 
-	p.template.level++
-	defer func() { p.template.level-- }()
+	p.Template.level++
+	defer func() { p.Template.level-- }()
 	return tag.parser(p, tokenName, argParser)
 }

--- a/tags_block.go
+++ b/tags_block.go
@@ -110,7 +110,7 @@ func tagBlockParser(doc *Parser, start *Token, arguments *Parser) (INodeTag, *Er
 		}
 	}
 
-	tpl := doc.template
+	tpl := doc.Template
 	if tpl == nil {
 		panic("internal error: tpl == nil")
 	}

--- a/tags_block.go
+++ b/tags_block.go
@@ -25,7 +25,7 @@ func (node *tagBlockNode) getBlockWrappers(tpl *Template) []*NodeWrapper {
 }
 
 func (node *tagBlockNode) Execute(ctx *ExecutionContext, writer TemplateWriter) *Error {
-	tpl := ctx.template
+	tpl := ctx.Template
 	if tpl == nil {
 		panic("internal error: tpl == nil")
 	}

--- a/tags_extends.go
+++ b/tags_extends.go
@@ -24,10 +24,10 @@ func tagExtendsParser(doc *Parser, start *Token, arguments *Parser) (INodeTag, *
 		// prepared, static template
 
 		// Get parent's filename
-		parentFilename := doc.Template.set.resolveFilename(doc.Template, filenameToken.Val)
+		parentFilename := doc.Template.Set.resolveFilename(doc.Template, filenameToken.Val)
 
 		// Parse the parent
-		parentTemplate, err := doc.Template.set.FromFile(parentFilename)
+		parentTemplate, err := doc.Template.Set.FromFile(parentFilename)
 		if err != nil {
 			return nil, err.(*Error)
 		}

--- a/tags_extends.go
+++ b/tags_extends.go
@@ -24,7 +24,7 @@ func tagExtendsParser(doc *Parser, start *Token, arguments *Parser) (INodeTag, *
 		// prepared, static template
 
 		// Get parent's filename
-		parentFilename := doc.Template.Set.resolveFilename(doc.Template, filenameToken.Val)
+		parentFilename := doc.Template.Set.ResolveFilename(doc.Template, filenameToken.Val)
 
 		// Parse the parent
 		parentTemplate, err := doc.Template.Set.FromFile(parentFilename)

--- a/tags_extends.go
+++ b/tags_extends.go
@@ -11,11 +11,11 @@ func (node *tagExtendsNode) Execute(ctx *ExecutionContext, writer TemplateWriter
 func tagExtendsParser(doc *Parser, start *Token, arguments *Parser) (INodeTag, *Error) {
 	extendsNode := &tagExtendsNode{}
 
-	if doc.template.level > 1 {
+	if doc.Template.level > 1 {
 		return nil, arguments.Error("The 'extends' tag can only defined on root level.", start)
 	}
 
-	if doc.template.parent != nil {
+	if doc.Template.parent != nil {
 		// Already one parent
 		return nil, arguments.Error("This template has already one parent.", start)
 	}
@@ -24,17 +24,17 @@ func tagExtendsParser(doc *Parser, start *Token, arguments *Parser) (INodeTag, *
 		// prepared, static template
 
 		// Get parent's filename
-		parentFilename := doc.template.set.resolveFilename(doc.template, filenameToken.Val)
+		parentFilename := doc.Template.set.resolveFilename(doc.Template, filenameToken.Val)
 
 		// Parse the parent
-		parentTemplate, err := doc.template.set.FromFile(parentFilename)
+		parentTemplate, err := doc.Template.set.FromFile(parentFilename)
 		if err != nil {
 			return nil, err.(*Error)
 		}
 
 		// Keep track of things
-		parentTemplate.child = doc.template
-		doc.template.parent = parentTemplate
+		parentTemplate.child = doc.Template
+		doc.Template.parent = parentTemplate
 		extendsNode.filename = parentFilename
 	} else {
 		return nil, arguments.Error("Tag 'extends' requires a template filename as string.", nil)

--- a/tags_import.go
+++ b/tags_import.go
@@ -32,7 +32,7 @@ func tagImportParser(doc *Parser, start *Token, arguments *Parser) (INodeTag, *E
 		return nil, arguments.Error("Import-tag needs a filename as string.", nil)
 	}
 
-	importNode.filename = doc.Template.Set.resolveFilename(doc.Template, filenameToken.Val)
+	importNode.filename = doc.Template.Set.ResolveFilename(doc.Template, filenameToken.Val)
 
 	if arguments.Remaining() == 0 {
 		return nil, arguments.Error("You must at least specify one macro to import.", nil)

--- a/tags_import.go
+++ b/tags_import.go
@@ -32,16 +32,16 @@ func tagImportParser(doc *Parser, start *Token, arguments *Parser) (INodeTag, *E
 		return nil, arguments.Error("Import-tag needs a filename as string.", nil)
 	}
 
-	importNode.filename = doc.template.set.resolveFilename(doc.template, filenameToken.Val)
+	importNode.filename = doc.Template.set.resolveFilename(doc.Template, filenameToken.Val)
 
 	if arguments.Remaining() == 0 {
 		return nil, arguments.Error("You must at least specify one macro to import.", nil)
 	}
 
 	// Compile the given template
-	tpl, err := doc.template.set.FromFile(importNode.filename)
+	tpl, err := doc.Template.set.FromFile(importNode.filename)
 	if err != nil {
-		return nil, err.(*Error).updateFromTokenIfNeeded(doc.template, start)
+		return nil, err.(*Error).updateFromTokenIfNeeded(doc.Template, start)
 	}
 
 	for arguments.Remaining() > 0 {

--- a/tags_import.go
+++ b/tags_import.go
@@ -32,14 +32,14 @@ func tagImportParser(doc *Parser, start *Token, arguments *Parser) (INodeTag, *E
 		return nil, arguments.Error("Import-tag needs a filename as string.", nil)
 	}
 
-	importNode.filename = doc.Template.set.resolveFilename(doc.Template, filenameToken.Val)
+	importNode.filename = doc.Template.Set.resolveFilename(doc.Template, filenameToken.Val)
 
 	if arguments.Remaining() == 0 {
 		return nil, arguments.Error("You must at least specify one macro to import.", nil)
 	}
 
 	// Compile the given template
-	tpl, err := doc.Template.set.FromFile(importNode.filename)
+	tpl, err := doc.Template.Set.FromFile(importNode.filename)
 	if err != nil {
 		return nil, err.(*Error).updateFromTokenIfNeeded(doc.Template, start)
 	}

--- a/tags_include.go
+++ b/tags_include.go
@@ -42,9 +42,9 @@ func (node *tagIncludeNode) Execute(ctx *ExecutionContext, writer TemplateWriter
 		}
 
 		// Get include-filename
-		includedFilename := ctx.template.set.resolveFilename(ctx.template, filename.String())
+		includedFilename := ctx.template.Set.resolveFilename(ctx.template, filename.String())
 
-		includedTpl, err2 := ctx.template.set.FromFile(includedFilename)
+		includedTpl, err2 := ctx.template.Set.FromFile(includedFilename)
 		if err2 != nil {
 			// if this is ReadFile error, and "if_exists" flag is enabled
 			if node.ifExists && err2.(*Error).Sender == "fromfile" {
@@ -84,11 +84,11 @@ func tagIncludeParser(doc *Parser, start *Token, arguments *Parser) (INodeTag, *
 		ifExists := arguments.Match(TokenIdentifier, "if_exists") != nil
 
 		// Get include-filename
-		includedFilename := doc.Template.set.resolveFilename(doc.Template, filenameToken.Val)
+		includedFilename := doc.Template.Set.resolveFilename(doc.Template, filenameToken.Val)
 
 		// Parse the parent
 		includeNode.filename = includedFilename
-		includedTpl, err := doc.Template.set.FromFile(includedFilename)
+		includedTpl, err := doc.Template.Set.FromFile(includedFilename)
 		if err != nil {
 			// if this is ReadFile error, and "if_exists" token presents we should create and empty node
 			if err.(*Error).Sender == "fromfile" && ifExists {

--- a/tags_include.go
+++ b/tags_include.go
@@ -42,7 +42,7 @@ func (node *tagIncludeNode) Execute(ctx *ExecutionContext, writer TemplateWriter
 		}
 
 		// Get include-filename
-		includedFilename := ctx.Template.Set.resolveFilename(ctx.Template, filename.String())
+		includedFilename := ctx.Template.Set.ResolveFilename(ctx.Template, filename.String())
 
 		includedTpl, err2 := ctx.Template.Set.FromFile(includedFilename)
 		if err2 != nil {
@@ -84,7 +84,7 @@ func tagIncludeParser(doc *Parser, start *Token, arguments *Parser) (INodeTag, *
 		ifExists := arguments.Match(TokenIdentifier, "if_exists") != nil
 
 		// Get include-filename
-		includedFilename := doc.Template.Set.resolveFilename(doc.Template, filenameToken.Val)
+		includedFilename := doc.Template.Set.ResolveFilename(doc.Template, filenameToken.Val)
 
 		// Parse the parent
 		includeNode.filename = includedFilename

--- a/tags_include.go
+++ b/tags_include.go
@@ -84,24 +84,24 @@ func tagIncludeParser(doc *Parser, start *Token, arguments *Parser) (INodeTag, *
 		ifExists := arguments.Match(TokenIdentifier, "if_exists") != nil
 
 		// Get include-filename
-		includedFilename := doc.template.set.resolveFilename(doc.template, filenameToken.Val)
+		includedFilename := doc.Template.set.resolveFilename(doc.Template, filenameToken.Val)
 
 		// Parse the parent
 		includeNode.filename = includedFilename
-		includedTpl, err := doc.template.set.FromFile(includedFilename)
+		includedTpl, err := doc.Template.set.FromFile(includedFilename)
 		if err != nil {
 			// if this is ReadFile error, and "if_exists" token presents we should create and empty node
 			if err.(*Error).Sender == "fromfile" && ifExists {
 				return &tagIncludeEmptyNode{}, nil
 			}
-			return nil, err.(*Error).updateFromTokenIfNeeded(doc.template, filenameToken)
+			return nil, err.(*Error).updateFromTokenIfNeeded(doc.Template, filenameToken)
 		}
 		includeNode.tpl = includedTpl
 	} else {
 		// No String, then the user wants to use lazy-evaluation (slower, but possible)
 		filenameEvaluator, err := arguments.ParseExpression()
 		if err != nil {
-			return nil, err.updateFromTokenIfNeeded(doc.template, filenameToken)
+			return nil, err.updateFromTokenIfNeeded(doc.Template, filenameToken)
 		}
 		includeNode.filenameEvaluator = filenameEvaluator
 		includeNode.lazy = true
@@ -121,7 +121,7 @@ func tagIncludeParser(doc *Parser, start *Token, arguments *Parser) (INodeTag, *
 			}
 			valueExpr, err := arguments.ParseExpression()
 			if err != nil {
-				return nil, err.updateFromTokenIfNeeded(doc.template, keyToken)
+				return nil, err.updateFromTokenIfNeeded(doc.Template, keyToken)
 			}
 
 			includeNode.withPairs[keyToken.Val] = valueExpr

--- a/tags_include.go
+++ b/tags_include.go
@@ -42,9 +42,9 @@ func (node *tagIncludeNode) Execute(ctx *ExecutionContext, writer TemplateWriter
 		}
 
 		// Get include-filename
-		includedFilename := ctx.template.Set.resolveFilename(ctx.template, filename.String())
+		includedFilename := ctx.Template.Set.resolveFilename(ctx.Template, filename.String())
 
-		includedTpl, err2 := ctx.template.Set.FromFile(includedFilename)
+		includedTpl, err2 := ctx.Template.Set.FromFile(includedFilename)
 		if err2 != nil {
 			// if this is ReadFile error, and "if_exists" flag is enabled
 			if node.ifExists && err2.(*Error).Sender == "fromfile" {

--- a/tags_macro.go
+++ b/tags_macro.go
@@ -45,7 +45,7 @@ func (node *tagMacroNode) call(ctx *ExecutionContext, args ...*Value) (*Value, e
 	if len(args) > len(node.argsOrder) {
 		// Too many arguments, we're ignoring them and just logging into debug mode.
 		err := ctx.Error(fmt.Sprintf("Macro '%s' called with too many arguments (%d instead of %d).",
-			node.name, len(args), len(node.argsOrder)), nil).updateFromTokenIfNeeded(ctx.template, node.position)
+			node.name, len(args), len(node.argsOrder)), nil).updateFromTokenIfNeeded(ctx.Template, node.position)
 
 		return AsSafeValue(""), err
 	}
@@ -63,7 +63,7 @@ func (node *tagMacroNode) call(ctx *ExecutionContext, args ...*Value) (*Value, e
 	var b bytes.Buffer
 	err := node.wrapper.Execute(macroCtx, &b)
 	if err != nil {
-		return AsSafeValue(""), err.updateFromTokenIfNeeded(ctx.template, node.position)
+		return AsSafeValue(""), err.updateFromTokenIfNeeded(ctx.Template, node.position)
 	}
 
 	return AsSafeValue(b.String()), nil

--- a/tags_macro.go
+++ b/tags_macro.go
@@ -133,11 +133,11 @@ func tagMacroParser(doc *Parser, start *Token, arguments *Parser) (INodeTag, *Er
 
 	if macroNode.exported {
 		// Now register the macro if it wants to be exported
-		_, has := doc.template.exportedMacros[macroNode.name]
+		_, has := doc.Template.exportedMacros[macroNode.name]
 		if has {
 			return nil, doc.Error(fmt.Sprintf("another macro with name '%s' already exported", macroNode.name), start)
 		}
-		doc.template.exportedMacros[macroNode.name] = macroNode
+		doc.Template.exportedMacros[macroNode.name] = macroNode
 	}
 
 	return macroNode, nil

--- a/tags_ssi.go
+++ b/tags_ssi.go
@@ -36,14 +36,14 @@ func tagSSIParser(doc *Parser, start *Token, arguments *Parser) (INodeTag, *Erro
 
 		if arguments.Match(TokenIdentifier, "parsed") != nil {
 			// parsed
-			temporaryTpl, err := doc.Template.set.FromFile(doc.Template.set.resolveFilename(doc.Template, fileToken.Val))
+			temporaryTpl, err := doc.Template.Set.FromFile(doc.Template.Set.resolveFilename(doc.Template, fileToken.Val))
 			if err != nil {
 				return nil, err.(*Error).updateFromTokenIfNeeded(doc.Template, fileToken)
 			}
 			SSINode.template = temporaryTpl
 		} else {
 			// plaintext
-			buf, err := ioutil.ReadFile(doc.Template.set.resolveFilename(doc.Template, fileToken.Val))
+			buf, err := ioutil.ReadFile(doc.Template.Set.resolveFilename(doc.Template, fileToken.Val))
 			if err != nil {
 				return nil, (&Error{
 					Sender:    "tag:ssi",

--- a/tags_ssi.go
+++ b/tags_ssi.go
@@ -36,19 +36,19 @@ func tagSSIParser(doc *Parser, start *Token, arguments *Parser) (INodeTag, *Erro
 
 		if arguments.Match(TokenIdentifier, "parsed") != nil {
 			// parsed
-			temporaryTpl, err := doc.template.set.FromFile(doc.template.set.resolveFilename(doc.template, fileToken.Val))
+			temporaryTpl, err := doc.Template.set.FromFile(doc.Template.set.resolveFilename(doc.Template, fileToken.Val))
 			if err != nil {
-				return nil, err.(*Error).updateFromTokenIfNeeded(doc.template, fileToken)
+				return nil, err.(*Error).updateFromTokenIfNeeded(doc.Template, fileToken)
 			}
 			SSINode.template = temporaryTpl
 		} else {
 			// plaintext
-			buf, err := ioutil.ReadFile(doc.template.set.resolveFilename(doc.template, fileToken.Val))
+			buf, err := ioutil.ReadFile(doc.Template.set.resolveFilename(doc.Template, fileToken.Val))
 			if err != nil {
 				return nil, (&Error{
 					Sender:    "tag:ssi",
 					OrigError: err,
-				}).updateFromTokenIfNeeded(doc.template, fileToken)
+				}).updateFromTokenIfNeeded(doc.Template, fileToken)
 			}
 			SSINode.content = string(buf)
 		}

--- a/tags_ssi.go
+++ b/tags_ssi.go
@@ -36,14 +36,14 @@ func tagSSIParser(doc *Parser, start *Token, arguments *Parser) (INodeTag, *Erro
 
 		if arguments.Match(TokenIdentifier, "parsed") != nil {
 			// parsed
-			temporaryTpl, err := doc.Template.Set.FromFile(doc.Template.Set.resolveFilename(doc.Template, fileToken.Val))
+			temporaryTpl, err := doc.Template.Set.FromFile(doc.Template.Set.ResolveFilename(doc.Template, fileToken.Val))
 			if err != nil {
 				return nil, err.(*Error).updateFromTokenIfNeeded(doc.Template, fileToken)
 			}
 			SSINode.template = temporaryTpl
 		} else {
 			// plaintext
-			buf, err := ioutil.ReadFile(doc.Template.Set.resolveFilename(doc.Template, fileToken.Val))
+			buf, err := ioutil.ReadFile(doc.Template.Set.ResolveFilename(doc.Template, fileToken.Val))
 			if err != nil {
 				return nil, (&Error{
 					Sender:    "tag:ssi",

--- a/template.go
+++ b/template.go
@@ -25,7 +25,7 @@ func (tw *templateWriter) Write(b []byte) (int, error) {
 }
 
 type Template struct {
-	set *TemplateSet
+	Set *TemplateSet
 
 	// Input
 	isTplString bool
@@ -61,7 +61,7 @@ func newTemplate(set *TemplateSet, name string, isTplString bool, tpl []byte) (*
 
 	// Create the template
 	t := &Template{
-		set:            set,
+		Set:            set,
 		isTplString:    isTplString,
 		name:           name,
 		tpl:            strTpl,
@@ -131,7 +131,7 @@ func (tpl *Template) newContextForExecution(context Context) (*Template, *Execut
 
 	// Create context if none is given
 	newContext := make(Context)
-	newContext.Update(tpl.set.Globals)
+	newContext.Update(tpl.Set.Globals)
 
 	if context != nil {
 		newContext.Update(context)

--- a/template_sets.go
+++ b/template_sets.go
@@ -81,7 +81,7 @@ func (set *TemplateSet) AddLoader(loaders ...TemplateLoader) {
 	set.loaders = append(set.loaders, loaders...)
 }
 
-func (set *TemplateSet) resolveFilename(tpl *Template, path string) string {
+func (set *TemplateSet) ResolveFilename(tpl *Template, path string) string {
 	return set.resolveFilenameForLoader(set.loaders[0], tpl, path)
 }
 
@@ -158,7 +158,7 @@ func (set *TemplateSet) CleanCache(filenames ...string) {
 	}
 
 	for _, filename := range filenames {
-		delete(set.templateCache, set.resolveFilename(nil, filename))
+		delete(set.templateCache, set.ResolveFilename(nil, filename))
 	}
 }
 
@@ -173,7 +173,7 @@ func (set *TemplateSet) FromCache(filename string) (*Template, error) {
 		return set.FromFile(filename)
 	}
 	// Cache the template
-	cleanedFilename := set.resolveFilename(nil, filename)
+	cleanedFilename := set.ResolveFilename(nil, filename)
 
 	set.templateCacheMutex.Lock()
 	defer set.templateCacheMutex.Unlock()

--- a/variable.go
+++ b/variable.go
@@ -660,7 +660,7 @@ filterLoop:
 		}
 
 		// Check sandbox filter restriction
-		if _, isBanned := p.Template.set.bannedFilters[filter.name]; isBanned {
+		if _, isBanned := p.Template.Set.bannedFilters[filter.name]; isBanned {
 			return nil, p.Error(fmt.Sprintf("Usage of filter '%s' is not allowed (sandbox restriction active).", filter.name), nil)
 		}
 

--- a/variable.go
+++ b/variable.go
@@ -660,7 +660,7 @@ filterLoop:
 		}
 
 		// Check sandbox filter restriction
-		if _, isBanned := p.template.set.bannedFilters[filter.name]; isBanned {
+		if _, isBanned := p.Template.set.bannedFilters[filter.name]; isBanned {
 			return nil, p.Error(fmt.Sprintf("Usage of filter '%s' is not allowed (sandbox restriction active).", filter.name), nil)
 		}
 


### PR DESCRIPTION
I am trying to make a custom tag that loads another template file like `include`, `extends` and `ssi` tag.
I checked these built-in tags implementation. They use the code such as `doc.template.set.resolveFilename(…)` and `doc.template.set.FromFile(…)` to load a template.

For example:

https://github.com/flosch/pongo2/blob/af96a40c67441cd0115b536609f9d1de2f979821/tags_include.go#L45

https://github.com/flosch/pongo2/blob/af96a40c67441cd0115b536609f9d1de2f979821/tags_include.go#L47

But the same code can’t be used in my custom tag implementation. Because, `doc.template`, `doc.template.set` and some methods are private.

This PR makes some field and methods public for implementing custom tags that load another templates. Could you please merge it?