### PR TITLE
Add support for numeric map keys

### DIFF
--- a/pongo2_issues_test.go
+++ b/pongo2_issues_test.go
@@ -27,3 +27,24 @@ func TestIssue151(t *testing.T) {
 		t.Fatalf("Expected output 'foobarbaz', but got '%s'.", str)
 	}
 }
+
+func TestNumericMapKey(t *testing.T) {
+	tpl, err := pongo2.FromString("{{ mydict.0 }}{{ mydict.2 }}")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	str, err := tpl.Execute(pongo2.Context{
+		"mydict": map[string]interface{}{
+			"0": "foo",
+			"1": "bar",
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if str != "foo" {
+		t.Fatalf("Expected output 'foo', but got '%s'.", str)
+	}
+}

--- a/variable.go
+++ b/variable.go
@@ -269,7 +269,7 @@ func (vr *variableResolver) resolve(ctx *ExecutionContext) (*Value, error) {
 				switch part.typ {
 				case varTypeInt:
 					// Calling an index is only possible for:
-					// * slices/arrays/strings
+					// * slices/arrays/strings/maps
 					switch current.Kind() {
 					case reflect.String, reflect.Array, reflect.Slice:
 						if part.i >= 0 && current.Len() > part.i {
@@ -278,6 +278,8 @@ func (vr *variableResolver) resolve(ctx *ExecutionContext) (*Value, error) {
 							// In Django, exceeding the length of a list is just empty.
 							return AsValue(nil), nil
 						}
+					case reflect.Map:
+						current = current.MapIndex(reflect.ValueOf(strconv.Itoa(part.i)))
 					default:
 						return nil, fmt.Errorf("Can't access an index on type %s (variable %s)",
 							current.Kind().String(), vr.String())


### PR DESCRIPTION
I have data from an external source which contains map[string]interface{} instances with numeric keys:
```
map[string]interface{}{
  "0": "foo",
  "1": "bar",
}
```

I'm trying to access this map via this template `{{ mydict.0 }}` as I would a regular map, but Pongo2 doesn't seem to allow this:
```
Can't access an index on type map (variable mydict.0)
```

This PR adds this capability.