### PR TITLE
feature: add loader for embed.FS

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,3 +168,36 @@ func main() {
     http.ListenAndServe(":8080", nil)
 }
 ```
+
+## Example using embed.FS
+
+Suppose we have this file in `templates/hello.html`
+```html
+<body>
+    Hello {{ name }}
+</body>
+</html>
+```
+
+To access the template use the relative path `templates/{path_to_file}`
+```go
+//go:embed templates
+var tplEmbed embed.FS
+
+func main() {
+	tplSet := pongo2.NewSet("mytemplate", pongo2.MustNewEmbededLoader(&tplEmbed))
+	tpl, err := tplSet.FromFile("templates/hello.html")
+	panicErr(err)
+
+	out, err := tpl.Execute(pongo2.Context{"name": "john"})
+	panicErr(err)
+
+	fmt.Println(out)
+}
+
+func panicErr(err error) {
+	if err != nil {
+		panic(err)
+	}
+}
+```

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/flosch/pongo2/v4
 
-go 1.14
+go 1.16
 
 require (
 	github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e // indirect

--- a/template_loader.go
+++ b/template_loader.go
@@ -252,11 +252,11 @@ func (e *EmbededLoader) Abs(base, name string) string {
 
 // Get returns an io.Reader where the template's content can be read from.
 func (e *EmbededLoader) Get(path string) (reader io.Reader, err error) {
+	// no call to fs.Close, because it did nothing
 	f, err := e.fs.Open(path)
 	if err != nil {
 		return nil, err
 	}
-	defer f.Close()
 
 	bt, err := io.ReadAll(f)
 	if err != nil {

--- a/template_loader.go
+++ b/template_loader.go
@@ -232,8 +232,7 @@ func MustNewEmbededLoader(fs *embed.FS) *EmbededLoader {
 }
 
 // NewEmbededLoader creates a new EmbededLoader and allows
-// templates to be loaded from the embed.FS. The path
-// is calculated based relatively baseDir
+// templates to be loaded from the embed.FS.
 func NewEmbededLoader(fs *embed.FS) (*EmbededLoader, error) {
 	if fs == nil {
 		err := errors.New("fs cannot be nil")

--- a/template_loader_test.go
+++ b/template_loader_test.go
@@ -1,0 +1,19 @@
+package pongo2_test
+
+import (
+	"embed"
+	"testing"
+
+	"github.com/flosch/pongo2/v4"
+)
+
+var (
+	//go:embed template_tests
+	testTemplateFS embed.FS
+)
+
+func TestEmbedFSLoader(t *testing.T) {
+	set := pongo2.NewSet("test embed", pongo2.MustNewEmbededLoader(testTemplateFS))
+	_ = pongo2.Must(set.FromFile("template_tests/complex.tpl"))
+	_ = pongo2.Must(set.FromFile("template_tests/inheritance/base.tpl"))
+}


### PR DESCRIPTION
Support loading template from Go `embed.FS`

To support `embed.FS` we need to upgrade the go module version to at least `v1.16`

There are also some limitations for the filename, please check:
- https://pkg.go.dev/embed#hdr-Directives
- https://github.com/golang/go/issues/43854