### PR TITLE
Added ability to customize the resolution of context contained variables.

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ Please use the [issue tracker](https://github.com/flosch/pongo2/issues) if you'r
 - [Advanced C-like expressions](https://github.com/flosch/pongo2/blob/master/template_tests/expressions.tpl).
 - [Complex function calls within expressions](https://github.com/flosch/pongo2/blob/master/template_tests/function_calls_wrapper.tpl).
 - [Easy API to create new filters and tags](http://godoc.org/github.com/flosch/pongo2#RegisterFilter) ([including parsing arguments](http://godoc.org/github.com/flosch/pongo2#Parser))
+- [Customizing variable resolution](http://godoc.org/github.com/flosch/pongo2#hdr-Variable_resolution)
 - Additional features:
   - Macros including importing macros from other files (see [template_tests/macro.tpl](https://github.com/flosch/pongo2/blob/master/template_tests/macro.tpl))
   - [Template sandboxing](https://godoc.org/github.com/flosch/pongo2#TemplateSet) ([directory patterns](http://golang.org/pkg/path/filepath/#Match), banned tags/filters)

--- a/context.go
+++ b/context.go
@@ -26,6 +26,54 @@ func SetAutoescape(newValue bool) {
 //     {{ myfunc("test", 42) }}
 //     {{ user.name }}
 //     {{ pongo2.version }}
+//
+// Variable resolution
+//
+// By the default sub variables are resolved by
+//  1. Field names inside structs
+//  2. Keys of values inside maps
+//  3. Indexes of values inside slices
+//
+// This behavior can be customized using either struct tag "pongo2" like:
+//     type MyStruct struct {
+//         FieldA string `pongo2:"uh"`
+//         FieldB string `pongo2:"yeah"`
+//     }
+//
+//     my.tmpl:
+//     {{ myStruct.uh }} {{ myStruct.yeah }}
+//
+// ...or by implementing NamedFieldResolver or IndexedFieldResolver.
+//
+//     type MyStruct struct {
+//         fieldA string
+//     }
+//
+//     // GetNamedField implements NamedFieldResolver
+//     func (s MyStruct) GetNamedField(s string) (interface{}, error) {
+//         switch s {
+//         case "uh":
+//             return s.fieldA, nil
+//         case "yeah":
+//             return "YEAH!", nil
+//         default:
+//             return nil, pongo2.ErrNoSuchField
+//     }
+//
+//     // GetNamedField implements IndexedFieldResolver
+//     func (s MyStruct) GetIndexedField(s int) (interface{}, error) {
+//         switch s {
+//         case 0:
+//             return s.fieldA, nil
+//         case 1:
+//             return "YEAH!", nil
+//         default:
+//             return nil, pongo2.ErrNoSuchField
+//     }
+//
+//     my.tmpl:
+//     {{ myStruct.uh }} {{ myStruct.yeah }}
+//     {{ myStruct.0 }} {{ myStruct.1 }}
 type Context map[string]interface{}
 
 func (c Context) checkForValidIdentifiers() *Error {

--- a/variable_test.go
+++ b/variable_test.go
@@ -1,0 +1,237 @@
+package pongo2_test
+
+import (
+	"errors"
+	"github.com/flosch/pongo2/v5"
+	"testing"
+)
+
+func TestVariables_Named(t *testing.T) {
+	tests := map[string]struct {
+		template      string
+		contextObject interface{}
+		want          string
+		wantErr       string
+	}{
+		"ByReflection": {
+			template:      "[{{ obj.Foo }}]",
+			contextObject: testVariablesStructSimple{Foo: "someFoo"},
+			want:          "[someFoo]",
+		},
+		"ByReflectionMethod": {
+			template:      "[{{ obj.GetBar }}]",
+			contextObject: testVariablesStructSimple{hiddenBar: "someBar"},
+			want:          "[someBar]",
+		},
+		"ByReflectionFunc": {
+			template:      "[{{ obj.SomeFuncVar }}]",
+			contextObject: testVariablesStructSimple{SomeFuncVar: func() string { return "fromFunc" }},
+			want:          "[fromFunc]",
+		},
+		"ByReflectionNotExported": {
+			template:      "[{{ obj.hiddenBar }}]",
+			contextObject: testVariablesStructSimple{hiddenBar: "someBar"},
+			want:          "[]",
+		},
+		"ByReflectionMethodNotExported": {
+			template:      "[{{ obj.hiddenGetBar }}]",
+			contextObject: testVariablesStructSimple{hiddenBar: "someBar"},
+			want:          "[]",
+		},
+		"ByNamed": {
+			template:      "[{{ obj.foo }}]",
+			contextObject: testVariablesStructNamed{hiddenFoo: "someFoo"},
+			want:          "[someFoo]",
+		},
+		"ByNamedFallback": {
+			template:      "[{{ obj.Bar }}]",
+			contextObject: testVariablesStructNamed{Bar: "someBar"},
+			want:          "[someBar]",
+		},
+		"ByNamedFailing": {
+			template:      "[{{ obj.explode }}]",
+			contextObject: testVariablesStructNamed{},
+			wantErr:       "[Error (where: execution) in <string> | Line 1 Col 5 near 'obj'] can't access field explode on type struct (variable obj.explode): expected",
+		},
+		"ByNamedFunc": {
+			template:      "[{{ obj.func }}]",
+			contextObject: testVariablesStructNamed{},
+			want:          "[fromFunc]",
+		},
+		"ByNamedAliased": {
+			template:      "[{{ obj.aliased }}]",
+			contextObject: testVariablesStructNamed{Aliased1: "expected"},
+			want:          "[expected]",
+		},
+		"ByNamedAliasedConflicting": {
+			template:      "[{{ obj.AliasedConflicting }}]",
+			contextObject: testVariablesStructNamed{Aliased2: "expected", AliasedConflicting: "not expected, because overwritten by Aliased2"},
+			want:          "[expected]",
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			tpl, _ := pongo2.FromString(tt.template)
+			got, err := tpl.Execute(map[string]interface{}{
+				"obj": tt.contextObject,
+			})
+			if err != nil {
+				if err.Error() != tt.wantErr {
+					t.Errorf("Template.Execute() error = %v, expected error: %v", err, tt.wantErr)
+					return
+				}
+			}
+			if got != tt.want {
+				t.Errorf("Template.Execute() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestVariables_Indexed(t *testing.T) {
+	tests := map[string]struct {
+		template      string
+		contextObject interface{}
+		want          string
+		wantErr       string
+	}{
+		"ByReflection": {
+			template:      "[{{ obj.1 }}]",
+			contextObject: []string{"a", "b", "c"},
+			want:          "[b]",
+		},
+		"ByReflectionFunc": {
+			template:      "[{{ obj.0 }}]",
+			contextObject: []interface{}{func() string { return "fromFunc" }},
+			want:          "[fromFunc]",
+		},
+		"ByIndexedOnSlice": {
+			template:      "[{{ obj.1 }}]",
+			contextObject: testVariablesSliceIndexed{"a", "b", "c"},
+			want:          "[theField]",
+		},
+		"ByIndexedFallbackOnSlice": {
+			template:      "[{{ obj.0 }}]",
+			contextObject: testVariablesSliceIndexed{"a", "b", "c"},
+			want:          "[a]",
+		},
+		"ByIndexedFailingOnSlice": {
+			template:      "[{{ obj.2 }}]",
+			contextObject: testVariablesSliceIndexed{"a", "b", "c"},
+			wantErr:       "[Error (where: execution) in <string> | Line 1 Col 5 near 'obj'] can't access index 2 on type slice (variable obj.2): expected",
+		},
+		"ByIndexedOnStruct": {
+			template:      "[{{ obj.1 }}]",
+			contextObject: testVariablesStructIndexed{hiddenFoo: "someFoo"},
+			want:          "[someFoo]",
+		},
+		"ByIndexedFallbackDoesNotWorkOnStruct": {
+			template:      "[{{ obj.0 }}]",
+			contextObject: testVariablesStructIndexed{hiddenFoo: "someFoo"},
+			wantErr:       "[Error (where: execution) in <string> | Line 1 Col 5 near 'obj'] can't access an index on type struct (variable obj.0)",
+		},
+		"ByIndexedFailingOnStruct": {
+			template:      "[{{ obj.2 }}]",
+			contextObject: testVariablesStructIndexed{hiddenFoo: "someFoo"},
+			wantErr:       "[Error (where: execution) in <string> | Line 1 Col 5 near 'obj'] can't access index 2 on type struct (variable obj.2): expected",
+		},
+		"ByIndexedFunc": {
+			template:      "[{{ obj.3 }}]",
+			contextObject: testVariablesStructIndexed{},
+			want:          "[fromFunc]",
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			tpl, _ := pongo2.FromString(tt.template)
+			got, err := tpl.Execute(map[string]interface{}{
+				"obj": tt.contextObject,
+			})
+			if err != nil {
+				if err.Error() != tt.wantErr {
+					t.Errorf("Template.Execute() error = %v, expected error: %v", err, tt.wantErr)
+					return
+				}
+			}
+			if got != tt.want {
+				t.Errorf("Template.Execute() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+type testVariablesStructSimple struct {
+	Foo         string
+	hiddenBar   string
+	SomeFuncVar func() string
+}
+
+func (tv testVariablesStructSimple) GetBar() string {
+	return tv.hiddenBar
+}
+
+func (tv testVariablesStructSimple) hiddenGetBar() string {
+	return tv.hiddenBar
+}
+
+type testVariablesStructNamed struct {
+	hiddenFoo string
+	Bar       string
+
+	Aliased1           string `pongo2:"aliased"`
+	Aliased2           string `pongo2:"AliasedConflicting"`
+	AliasedConflicting string
+}
+
+func (tv testVariablesStructNamed) GetNamedField(s string) (interface{}, error) {
+	switch s {
+	case "foo":
+		return tv.hiddenFoo, nil
+	case "explode":
+		return nil, errTestExpected
+	case "func":
+		return func() string {
+			return "fromFunc"
+		}, nil
+	default:
+		return nil, pongo2.ErrNoSuchField
+	}
+}
+
+type testVariablesStructIndexed struct {
+	hiddenFoo string
+}
+
+func (tv testVariablesStructIndexed) GetIndexedField(s int) (interface{}, error) {
+	switch s {
+	case 1:
+		return tv.hiddenFoo, nil
+	case 2:
+		return nil, errTestExpected
+	case 3:
+		return func() string {
+			return "fromFunc"
+		}, nil
+	default:
+		return nil, pongo2.ErrNoSuchField
+	}
+}
+
+type testVariablesSliceIndexed []string
+
+func (tv testVariablesSliceIndexed) GetIndexedField(s int) (interface{}, error) {
+	switch s {
+	case 1:
+		return "theField", nil
+	case 2:
+		return nil, errTestExpected
+	default:
+		return nil, pongo2.ErrNoSuchField
+	}
+}
+
+var (
+	errTestExpected = errors.New("expected")
+)


### PR DESCRIPTION
Added ability to customize the resolution of context contained variables, by:
1. `NamedFieldResolver.GetNamedField(name)` and `IndexedFieldResolver.GetIndexedField(index)` interfaces
2. Struct field `pongo2:"..."`

Plus: Added security enforcement to never use **not** exported fields.