### PR TITLE
Improve ExecuteBlocks performance.

### DIFF
--- a/template_tests/block_render/deep.tpl
+++ b/template_tests/block_render/deep.tpl
@@ -1,0 +1,5 @@
+{% extends "../inheritance/base3.tpl" %}
+
+{% block more_content %}
+The nested content
+{% endblock %}

--- a/template_tests/block_render/deep.tpl.out
+++ b/template_tests/block_render/deep.tpl.out
@@ -1,0 +1,4 @@
+
+The content
+
+The nested content

--- a/template_tests/inheritance/base3.tpl
+++ b/template_tests/inheritance/base3.tpl
@@ -1,0 +1,1 @@
+{% extends "inheritance3/skeleton.tpl" %}

--- a/template_tests/inheritance/inheritance3/skeleton.tpl
+++ b/template_tests/inheritance/inheritance3/skeleton.tpl
@@ -1,0 +1,5 @@
+{% extends "../inheritance2/skeleton.tpl" %}
+
+{% block content %}
+The content
+{% endblock %}


### PR DESCRIPTION
The efficiency of `ExecuteBlocks` was pretty poor. This improves it by:

- Only visiting the parent if it has a block that is being sought after
- When we first try to render a block in a template, rather then when we first visit the template
    - Assign the buffer
    - Assign the context

The results were pretty staggering, specifically when passing an empty block array, or when working on deeply nested inheritance.

```
// When passing empty blocks
// Original
BenchmarkExecuteBlocksWithEmptyBlocksSandboxActive-6   	  675499	      1746 ns/op	     952 B/op	       9 allocs/op
// New
BenchmarkExecuteBlocksWithEmptyBlocksSandboxActive-6   	26332879	        44.17 ns/op	      48 B/op	       1 allocs/op

// When passing blocks
// Original
BenchmarkExecuteBlocksWithoutSandbox-6   	  687286	      1792 ns/op	    1261 B/op	      12 allocs/op
// New
BenchmarkExecuteBlocksWithoutSandbox-6   	  690864	      1763 ns/op	    1261 B/op	      12 allocs/op

// With very deep inheritance
// Original
BenchmarkExecuteBlocksDeepWithSandboxActive-6   	  158157	      7230 ns/op	    3920 B/op	      35 allocs/op
// New
BenchmarkExecuteBlocksDeepWithSandboxActive-6   	  304110	      3950 ns/op	    2192 B/op	      21 allocs/op
```