### PR TITLE
should not escape `block.Super`

### DIFF
--- a/tags_block.go
+++ b/tags_block.go
@@ -56,11 +56,11 @@ type tagBlockInformation struct {
 	wrappers []*NodeWrapper
 }
 
-func (t tagBlockInformation) Super() string {
+func (t tagBlockInformation) Super() (*Value, error) {
 	lenWrappers := len(t.wrappers)
 
 	if lenWrappers == 0 {
-		return ""
+		return AsSafeValue(""), nil
 	}
 
 	superCtx := NewChildExecutionContext(t.ctx)
@@ -73,9 +73,9 @@ func (t tagBlockInformation) Super() string {
 	buf := bytes.NewBufferString("")
 	err := blockWrapper.Execute(superCtx, &templateWriter{buf})
 	if err != nil {
-		return ""
+		return AsSafeValue(""), err
 	}
-	return buf.String()
+	return AsSafeValue(buf.String()), nil
 }
 
 func tagBlockParser(doc *Parser, start *Token, arguments *Parser) (INodeTag, *Error) {

--- a/template_tests/extends_super3.tpl
+++ b/template_tests/extends_super3.tpl
@@ -1,0 +1,3 @@
+{% extends "inheritance/base4.tpl" %}
+
+{% block content %}{{ block.Super }}<p>super3 content</p>{% endblock %}

--- a/template_tests/extends_super3.tpl.out
+++ b/template_tests/extends_super3.tpl.out
@@ -1,0 +1,1 @@
+<p>base4 content</p><p>super3 content</p>

--- a/template_tests/extends_super4.tpl
+++ b/template_tests/extends_super4.tpl
@@ -1,0 +1,3 @@
+{% extends "extends_super3.tpl" %}
+
+{% block content %}{{ block.Super }}<p>super4 content</p>{% endblock %}

--- a/template_tests/extends_super4.tpl.out
+++ b/template_tests/extends_super4.tpl.out
@@ -1,0 +1,1 @@
+<p>base4 content</p><p>super3 content</p><p>super4 content</p>

--- a/template_tests/inheritance/base4.tpl
+++ b/template_tests/inheritance/base4.tpl
@@ -1,0 +1,1 @@
+{% block content %}<p>base4 content</p>{% endblock %}


### PR DESCRIPTION
This PR changes the `block.Super` output. Because the output content should not be escaped.

The `block.Super` in the current implementation returns an escaped content. Please see the following example.

layout.tpl
```
{% block content %}<h1>Title</h1>{% endblock %}
```

page.tpl
```
{% extends "layout.tpl" %}

{% block content %}
{{ block.Super }}
<p>page contents</p>
{% endblock %}
```

These templates output the following content.

```
&lt;h1&gt;Title&lt;/h1&gt;
<p>page contents</p>
```

But it is not the same behavior as Django template. The Django official document (https://django.readthedocs.io/en/1.7.x/topics/templates.html) says the following.

> Data inserted using {{ block.super }} will not be automatically escaped (see the next section), since it was already escaped, if necessary, in the parent template.

Therefore, `block.Super` should output content that is not escaped from like the following.

```
<h1>Title</h1>
<p>page contents</p>
``` 
