### PR TITLE
README: Detailed installation commands needed

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,9 @@ pongo2 is a Django-syntax like templating-language ([official website](https://w
 Install/update using `go get` (no dependencies required by pongo2):
 
 ```sh
+# for Go >= 1.18:
+go install github.com/flosch/pongo2@latest
+# for Go < 1.18:
 go get -u github.com/flosch/pongo2/v6
 ```
 

--- a/README.md
+++ b/README.md
@@ -9,10 +9,9 @@ pongo2 is a Django-syntax like templating-language ([official website](https://w
 Install/update using `go get` (no dependencies required by pongo2):
 
 ```sh
-# for Go >= 1.18:
-go install github.com/flosch/pongo2@latest
-# for Go < 1.18:
+cd /path/to/folder_containing_go.mod_file
 go get -u github.com/flosch/pongo2/v6
+go mod tidy
 ```
 
 Please use the [issue tracker](https://github.com/flosch/pongo2/issues) if you're encountering any problems with pongo2 or if you need help with implementing tags or filters ([create a ticket!](https://github.com/flosch/pongo2/issues/new)).


### PR DESCRIPTION
> pongo2 is not an executable, but a library. Go get continues to work totally fine.

_Originally posted by @flosch in https://github.com/flosch/pongo2/issues/323#issuecomment-1378171445_

I apologize, I was wrong. However, I still couldn't install pongo2 with the `go get -u github.com/flosch/pongo2/v6` command alone. Please see the following commit for additional commands that, I believe, need to be added to the installtion instructions: https://github.com/flosch/pongo2/commit/06eec7f28521baf27e6148cda56ea289f3487485