### PR TITLE
urlize: escape text once and isolate mail linking

### DIFF
--- a/filters_builtin.go
+++ b/filters_builtin.go
@@ -1355,64 +1355,82 @@ var (
 )
 
 func filterUrlizeHelper(input string, autoescape bool, trunc int) (string, error) {
-	var soutErr error
-	sout := filterUrlizeURLRegexp.ReplaceAllStringFunc(input, func(raw_url string) string {
-		var prefix string
-		var suffix string
-		if strings.HasPrefix(raw_url, " ") {
-			prefix = " "
+	var out strings.Builder
+	out.Grow(len(input))
+	last := 0
+	for _, match := range filterUrlizeURLRegexp.FindAllStringIndex(input, -1) {
+		writeUrlizeText(&out, input[last:match[0]], autoescape, trunc)
+		if err := writeUrlizeURL(&out, input[match[0]:match[1]], autoescape, trunc); err != nil {
+			return "", err
 		}
-		if strings.HasSuffix(raw_url, " ") {
-			suffix = " "
-		}
+		last = match[1]
+	}
+	writeUrlizeText(&out, input[last:], autoescape, trunc)
+	return out.String(), nil
+}
 
-		raw_url = strings.TrimSpace(raw_url)
+// writeUrlizeText handles only a text run between URL matches. Keeping the
+// mail pass out of generated anchors prevents an address in a URL from
+// corrupting the href that was just emitted.
+func writeUrlizeText(out *strings.Builder, text string, autoescape bool, trunc int) {
+	last := 0
+	for _, match := range filterUrlizeEmailRegexp.FindAllStringIndex(text, -1) {
+		writeUrlizeEscaped(out, text[last:match[0]], autoescape)
+		mail := text[match[0]:match[1]]
+		out.WriteString(`<a href="mailto:`)
+		out.WriteString(mail)
+		out.WriteString(`">`)
+		writeUrlizeEscaped(out, truncateUrlizeTitle(mail, trunc), autoescape)
+		out.WriteString(`</a>`)
+		last = match[1]
+	}
+	writeUrlizeEscaped(out, text[last:], autoescape)
+}
 
-		t, err := ApplyFilter("iriencode", AsValue(raw_url), nil)
-		if err != nil {
-			soutErr = err
-			return ""
-		}
-		url := t.String()
-
-		if !strings.HasPrefix(url, "http") {
-			url = fmt.Sprintf("http://%s", url)
-		}
-
-		title := raw_url
-
-		titleRunes := []rune(title)
-		if trunc > 1 && len(titleRunes) > trunc {
-			title = string(titleRunes[:trunc-1]) + ellipsis
-		}
-
-		if autoescape {
-			t, err := ApplyFilter("escape", AsValue(title), nil)
-			if err != nil {
-				soutErr = err
-				return ""
-			}
-			title = t.String()
-		}
-
-		return fmt.Sprintf(`%s<a href="%s" rel="nofollow">%s</a>%s`, prefix, url, title, suffix)
-	})
-	if soutErr != nil {
-		return "", soutErr
+func writeUrlizeURL(out *strings.Builder, match string, autoescape bool, trunc int) error {
+	prefix, suffix := "", ""
+	if strings.HasPrefix(match, " ") {
+		prefix = " "
+	}
+	if strings.HasSuffix(match, " ") {
+		suffix = " "
+	}
+	rawURL := strings.TrimSpace(match)
+	encoded, err := ApplyFilter("iriencode", AsValue(rawURL), nil)
+	if err != nil {
+		return err
+	}
+	url := encoded.String()
+	if !strings.HasPrefix(url, "http") {
+		url = fmt.Sprintf("http://%s", url)
 	}
 
-	sout = filterUrlizeEmailRegexp.ReplaceAllStringFunc(sout, func(mail string) string {
-		title := mail
+	out.WriteString(prefix)
+	out.WriteString(`<a href="`)
+	out.WriteString(url)
+	out.WriteString(`" rel="nofollow">`)
+	writeUrlizeEscaped(out, truncateUrlizeTitle(rawURL, trunc), autoescape)
+	out.WriteString(`</a>`)
+	out.WriteString(suffix)
+	return nil
+}
 
-		titleRunes := []rune(title)
-		if trunc > 1 && len(titleRunes) > trunc {
-			title = string(titleRunes[:trunc-1]) + ellipsis
-		}
+func writeUrlizeEscaped(out *strings.Builder, text string, autoescape bool) {
+	if autoescape {
+		text = htmlEscapeReplacer.Replace(text)
+	}
+	out.WriteString(text)
+}
 
-		return fmt.Sprintf(`<a href="mailto:%s">%s</a>`, mail, title)
-	})
-
-	return sout, nil
+// truncateUrlizeTitle counts the unescaped URL or mail address. Escaping may
+// expand one character into an entity, but it must not change the visible
+// truncation point.
+func truncateUrlizeTitle(title string, trunc int) string {
+	runes := []rune(title)
+	if trunc > 1 && len(runes) > trunc {
+		return string(runes[:trunc-1]) + ellipsis
+	}
+	return title
 }
 
 // filterUrlize converts URLs and email addresses in plain text into clickable links.

--- a/urlize_render_test.go
+++ b/urlize_render_test.go
@@ -1,0 +1,74 @@
+package pongo2
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestURLizeEscapesPlainTextAndAnchorTextOnce(t *testing.T) {
+	t.Parallel()
+	input := `<b> https://x.y/?a=1&b=2`
+	got, err := filterUrlizeHelper(input, true, -1)
+	if err != nil {
+		t.Fatalf("filterUrlizeHelper: %v", err)
+	}
+	want := `&lt;b&gt; <a href="https://x.y/?a=1&b=2" rel="nofollow">` +
+		`https://x.y/?a=1&amp;b=2</a>`
+	if got != want {
+		t.Fatalf("filterUrlizeHelper(%q) = %q, want %q", input, got, want)
+	}
+	if strings.Contains(got, "&amp;amp;") {
+		t.Fatalf("anchor text was escaped twice: %q", got)
+	}
+}
+
+func TestURLizeTruncationCountsTheUnescapedURL(t *testing.T) {
+	t.Parallel()
+	input := `https://example.com/?q="1"&r='2'&s=3`
+	got, err := filterUrlizeHelper(input, true, len([]rune(input)))
+	if err != nil {
+		t.Fatalf("filterUrlizeHelper: %v", err)
+	}
+	if strings.Contains(got, ellipsis) {
+		t.Fatalf("exact-length URL was truncated after escaping: %q", got)
+	}
+	wantTitle := htmlEscapeReplacer.Replace(input)
+	if !strings.Contains(got, `>`+wantTitle+`</a>`) {
+		t.Fatalf("anchor title = %q, want escaped %q", got, wantTitle)
+	}
+}
+
+func TestURLizeMailPassSkipsGeneratedURLAnchors(t *testing.T) {
+	t.Parallel()
+	input := `https://example.com/bob@example.com then bob@example.com`
+	got, err := filterUrlizeHelper(input, true, -1)
+	if err != nil {
+		t.Fatalf("filterUrlizeHelper: %v", err)
+	}
+	if strings.Count(got, `<a href=`) != 2 {
+		t.Fatalf("anchor count = %d, want URL plus trailing mail: %q",
+			strings.Count(got, `<a href=`), got)
+	}
+	if strings.Contains(got, `href="https://example.com/<a`) ||
+		strings.Contains(got, `href="mailto:example.com`) {
+		t.Fatalf("mail pass rewrote the generated URL anchor: %q", got)
+	}
+	wantURL := `<a href="https://example.com/bob@example.com" rel="nofollow">` +
+		`https://example.com/bob@example.com</a>`
+	if !strings.Contains(got, wantURL) ||
+		!strings.Contains(got, `<a href="mailto:bob@example.com">bob@example.com</a>`) {
+		t.Fatalf("unexpected URL/mail rendering: %q", got)
+	}
+}
+
+func TestURLizeCanLeaveTrustedTextUnescaped(t *testing.T) {
+	t.Parallel()
+	input := `<b>www.example.com</b>`
+	got, err := filterUrlizeHelper(input, false, -1)
+	if err != nil {
+		t.Fatalf("filterUrlizeHelper: %v", err)
+	}
+	if !strings.HasPrefix(got, "<b>") {
+		t.Fatalf("autoescape=false changed trusted prefix: %q", got)
+	}
+}


### PR DESCRIPTION
## Summary

- escape ordinary text runs as well as URL anchor text when `urlize` autoescape is enabled
- truncate using the unescaped URL/mail address so HTML entities do not move the visible limit
- run email linking only over text between URL matches, never over anchors generated by the URL pass

## Why

The current two-pass replacement first emits URL anchors and then applies the email regexp to that generated HTML. An email-shaped substring inside a URL can therefore be replaced inside the new `href`. In addition, autoescape only covers matched URL titles; unmatched input is returned inside an `AsSafeValue` unchanged.

Building the result from alternating text and URL runs makes provenance explicit. Each raw text/title run is escaped at most once, and generated markup is never scanned as input.

## Verification

- `go test ./...`
- `go test -race ./...`
- `go vet ./...`
